### PR TITLE
Use non-comment type annotation

### DIFF
--- a/ethpm/__init__.py
+++ b/ethpm/__init__.py
@@ -11,6 +11,6 @@ if sys.version_info.major < 3:
 
 
 BASE_DIR = os.path.dirname(__file__)
-ASSETS_DIR = os.path.join(BASE_DIR, 'assets')  # type: str
+ASSETS_DIR: str = os.path.join(BASE_DIR, 'assets')
 
 from .package import Package  # noqa: F401


### PR DESCRIPTION
### What was wrong?

The comment type annotations are only needed for Python 3.5 support which I assume isn't a goal for this project. Comment type annotations have several disadvantages over proper ones.

### How was it fixed?

Used proper type annotation.

#### Cute Animal Picture

![Cute animal picture](https://images.unsplash.com/photo-1454991727061-be514eae86f7?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ec72773fad18bc596343f5b8b661a289&auto=format&fit=crop&w=1350&q=80)
