### PR TITLE
Write `Package.from_ipfs` class method

### DIFF
--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -24,6 +24,11 @@ from ethpm.utils.contract import (
 from ethpm.utils.deployment_validation import (
     validate_single_matching_uri,
 )
+from ethpm.utils.ipfs import (
+    extract_ipfs_path_from_uri,
+    fetch_ipfs_package,
+    is_ipfs_uri,
+)
 from ethpm.utils.package_validation import (
     check_for_build_dependencies,
     validate_package_against_schema,
@@ -116,8 +121,27 @@ class Package(object):
             package_data = _load_package_data_from_file(file_path_or_obj)
         else:
             raise TypeError(
-                "The Package.from_filemethod takes either a filesystem path or a file-like object. "
+                "The Package.from_file method takes either a filesystem path or a file-like object."
                 "Got {0} instead.".format(type(file_path_or_obj))
+            )
+
+        return cls(package_data)
+
+    @classmethod
+    def from_ipfs(cls, ipfs_uri: str) -> 'Package':
+        """
+        Allows users to create a Package object from
+        an IPFS uri.
+        TODO: Defaults to Infura gateway, needs extension
+        to support other gateways and local nodes
+        """
+        if is_ipfs_uri(ipfs_uri):
+            ipfs_path = extract_ipfs_path_from_uri(ipfs_uri)
+            package_data = fetch_ipfs_package(ipfs_path)
+        else:
+            raise TypeError(
+                "The Package.from_ipfs method only accepts a valid IPFS uri."
+                "{0} is not a valid IPFS uri.".format(ipfs_uri)
             )
 
         return cls(package_data)

--- a/ethpm/utils/ipfs.py
+++ b/ethpm/utils/ipfs.py
@@ -1,0 +1,40 @@
+import requests
+
+from typing import (
+    Any,
+    Dict,
+)
+
+from urllib import parse
+
+
+INFURA_IPFS_URI_PREFIX = "https://ipfs.infura.io/ipfs/"
+
+
+def fetch_ipfs_package(hash: str) -> Dict[str, Any]:
+    package_uri = INFURA_IPFS_URI_PREFIX + hash
+    response = requests.get(package_uri)
+    response.raise_for_status()
+    return response.json()
+
+
+def extract_ipfs_path_from_uri(value: str) -> str:
+    parse_result = parse.urlparse(value)
+
+    if parse_result.netloc:
+        if parse_result.path:
+            return ''.join((parse_result.netloc, parse_result.path))
+        else:
+            return parse_result.netloc
+    else:
+        return parse_result.path.lstrip('/')
+
+
+def is_ipfs_uri(value: str) -> bool:
+    parse_result = parse.urlparse(value)
+    if parse_result.scheme != 'ipfs':
+        return False
+    if not parse_result.netloc and not parse_result.path:
+        return False
+
+    return True

--- a/tests/ethpm/test_ipfs_utils.py
+++ b/tests/ethpm/test_ipfs_utils.py
@@ -1,0 +1,95 @@
+import pytest
+
+from ethpm.utils.ipfs import (
+    extract_ipfs_path_from_uri,
+    is_ipfs_uri,
+)
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        (
+            'ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
+        ),
+        (
+            'ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
+        ),
+        (
+            'ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
+        ),
+        (
+            'ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
+        ),
+        (
+            'ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
+        ),
+        (
+            'ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
+        ),
+        (
+            'ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
+        ),
+        (
+            'ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
+        ),
+        (
+            'ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
+        ),
+        (
+            'ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
+        ),
+        (
+            'ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
+        ),
+        (
+            'ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
+            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
+        ),
+    )
+)
+def test_extract_ipfs_path_from_uri(value, expected):
+    actual = extract_ipfs_path_from_uri(value)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u', True),
+        ('ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u', True),
+        ('ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u', True),
+        ('ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/', True),
+        ('ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/', True),
+        ('ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/', True),
+        ('ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme', True),
+        ('ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme', True),
+        ('ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme', True),
+        ('ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', True),
+        ('ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', True),
+        ('ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', True),
+        # malformed
+        ('ipfs//QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', False),
+        ('ipfs/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', False),
+        ('ipfsQmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', False),
+        # HTTP
+        ('http://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme', False),
+        ('https://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme', False),
+        # No hash
+        ('ipfs://', False),
+    )
+)
+def test_is_ipfs_uri(value, expected):
+    actual = is_ipfs_uri(value)
+    assert actual is expected

--- a/tests/ethpm/test_package_ipfs_initialization.py
+++ b/tests/ethpm/test_package_ipfs_initialization.py
@@ -1,0 +1,38 @@
+import pytest
+
+import ethpm
+
+from ethpm import Package
+
+VALID_IPFS_PKG = 'ipfs://QmeD2s7KaBUoGYTP1eutHBmBkMMMoycdfiyGMx2DKrWXyV'
+
+
+# mock out http req to IPFS gateway
+# `fetch_ipfs_package` returns local 'safe-math-lib` pkg
+@pytest.fixture(autouse=True)
+def mock_request(monkeypatch, valid_package):
+    def mock_fetch(x):
+        return valid_package
+    monkeypatch.setattr(ethpm.package, 'fetch_ipfs_package', mock_fetch)
+
+
+def test_package_from_ipfs_with_valid_uri(valid_package):
+    package = Package.from_ipfs(VALID_IPFS_PKG)
+    assert package.name == 'safe-math-lib'
+    assert isinstance(package, Package)
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    (
+        '123',
+        b'123',
+        {},
+        'ipfs://',
+        'http://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
+        'ipfsQmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
+    )
+)
+def test_package_from_ipfs_rejects_invalid_ipfs_uri(invalid):
+    with pytest.raises(TypeError):
+        Package.from_ipfs(invalid)


### PR DESCRIPTION
### What was wrong?
Lacked functionality to instantiate a `Package` from an IPFS uri


### How was it fixed?
Jacked some utils from Populus, and added a class method (`from_ipfs`) to `Package` class that creates a `Package` if the IPFS uri resolves to a valid Package

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/40319360-20f3806c-5ce5-11e8-9f95-9fef2836849b.png)
