### PR TITLE
Write registry uri validation utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ scheme://authority/package-name/version
 
 * URI must be a string type
 * `scheme`: `ercxxx` 
-* `authority`: Must be a valid ENS domain or a valid hex address pointing towards a registry contract.
+* `authority`: Must be a valid ENS domain or a valid checksum address pointing towards a registry contract.
 * `package-name`: Must conform to the package-name as specified in the [EthPM-Spec](http://ethpm-spec.readthedocs.io/en/latest/package-spec.html#package-name).
-* `version`: Must be a valid semver string as specified [here](https://semver.org/).
+* `version`: The URI escaped version string.
 
 i.e. `ercxxx://packages.zeppelinos.eth/owned/1.0.0`

--- a/README.md
+++ b/README.md
@@ -114,3 +114,20 @@ The `Package` class should provide access to the full dependency tree.
 ```sh
 git submodule init
 ```
+
+
+## Registry URI 
+
+The URI to lookup a package from a registry should follow the following format. (subject to change as the Registry Contract Standard makes it's way through the EIP process)
+
+```
+scheme://authority/package-name/version
+```
+
+* URI must be a string type
+* `scheme`: `ercxxx` 
+* `authority`: Must be a valid ENS domain or a valid hex address pointing towards a registry contract.
+* `package-name`: Must conform to the package-name as specified in the [EthPM-Spec](http://ethpm-spec.readthedocs.io/en/latest/package-spec.html#package-name).
+* `version`: Must be a valid semver string as specified [here](https://semver.org/).
+
+i.e. `ercxxx://packages.zeppelinos.eth/owned/1.0.0`

--- a/README.md
+++ b/README.md
@@ -121,13 +121,13 @@ git submodule init
 The URI to lookup a package from a registry should follow the following format. (subject to change as the Registry Contract Standard makes it's way through the EIP process)
 
 ```
-scheme://authority/package-name/version
+scheme://authority/package-name?version=x.x.x
 ```
 
 * URI must be a string type
 * `scheme`: `ercxxx` 
 * `authority`: Must be a valid ENS domain or a valid checksum address pointing towards a registry contract.
 * `package-name`: Must conform to the package-name as specified in the [EthPM-Spec](http://ethpm-spec.readthedocs.io/en/latest/package-spec.html#package-name).
-* `version`: The URI escaped version string.
+* `version`: The URI escaped version string, *should* conform to the [semver](http://semver.org/) version numbering specification.
 
-i.e. `ercxxx://packages.zeppelinos.eth/owned/1.0.0`
+i.e. `ercxxx://packages.zeppelinos.eth/owned?version=1.0.0`

--- a/ethpm/constants.py
+++ b/ethpm/constants.py
@@ -1,0 +1,4 @@
+# TODO update once registry standard eip has been approved
+REGISTRY_URI_SCHEME = 'ercxxx'
+
+PACKAGE_NAME_REGEX = '[a-zA-Z][-_a-zA-Z0-9]{0,255}'

--- a/ethpm/exceptions.py
+++ b/ethpm/exceptions.py
@@ -5,6 +5,12 @@ class InsufficientAssetsError(Exception):
     """
 
 
+class UriNotSupportedError(Exception):
+    """
+    Error to signal a URI scheme is not supported.
+    """
+
+
 class ValidationError(Exception):
     """
     Error to signal something does not pass a validation check.

--- a/ethpm/exceptions.py
+++ b/ethpm/exceptions.py
@@ -1,18 +1,20 @@
 class InsufficientAssetsError(Exception):
     """
-    Error to signal a Manifest or Package does not
+    Raised when a Manifest or Package does not
     contain the required assets to do something.
     """
-
-
-class UriNotSupportedError(Exception):
-    """
-    Error to signal a URI scheme is not supported.
-    """
+    pass
 
 
 class ValidationError(Exception):
     """
-    Error to signal something does not pass a validation check.
+    Raised when something does not pass a validation check.
+    """
+    pass
+
+
+class UriNotSupportedError(ValidationError):
+    """
+    Raised when URI scheme does not conform to the registry URI scheme.
     """
     pass

--- a/ethpm/utils/registry.py
+++ b/ethpm/utils/registry.py
@@ -1,0 +1,87 @@
+import re
+import semver
+
+from urllib import parse
+
+from typing import List
+
+from eth_utils import (
+    is_hex_address,
+)
+
+from ethpm.exceptions import UriNotSupportedError
+
+
+# TODO: update with correct scheme once ERC is completed
+REGISTRY_URI_SCHEME = 'ercxxx'
+PACKAGE_NAME_REGEX = '[a-zA-Z][-_a-zA-Z0-9]{0,255}'
+
+
+def is_valid_authority(auth: str) -> None:
+    """
+    Raises exception if authority is not a valid ENS domain or contract address.
+    """
+    if is_ens_domain(auth) is False and not is_hex_address(auth):
+        raise UriNotSupportedError('{0} is not a valid registry URI authority.'.format(auth))
+
+
+def is_ens_domain(auth: str) -> bool:
+    """
+    Returns false if URI authority is not a valid ENS domain.
+    """
+    if auth[-4:] != '.eth' or len(auth.split('.')) not in [2, 3]:
+        return False
+    return True
+
+
+def is_valid_semver(pkg_version: str) -> None:
+    """
+    Raises exception if package version is not valid semver.
+    """
+    try:
+        semver.parse(pkg_version)
+    except ValueError as exc:
+        raise UriNotSupportedError('{0} is not a valid registry URI version.'.format(pkg_version))
+
+
+def is_valid_package_name(pkg_name: str) -> None:
+    """
+    Returns boolean if the value is a valid package name.
+    """
+    if not bool(re.match(PACKAGE_NAME_REGEX, pkg_name)):
+        raise UriNotSupportedError('{0} is not a valid package name.'.format(pkg_name))
+
+
+def is_valid_scheme(scheme: str) -> None:
+    """
+    Raises exception is package scheme is not a valid scheme.
+    """
+    if scheme != REGISTRY_URI_SCHEME:
+        raise UriNotSupportedError('{0} is not a valid registry URI scheme.'.format(scheme))
+
+
+def parse_path(path: str) -> List[str]:
+    """
+    Raises exception if path is not a valid path.
+    If path is valid, return the name and version
+    """
+    if not path:
+        raise UriNotSupportedError('{0} is not a valid registry URI path.'.format(path))
+    return path.split('/')[1:3]
+
+
+def is_registry_uri(uri: str) -> bool:
+    """
+    Returns True if URI is a valid registry URI.
+    Raises UriNotSupportedError if URI is an invalid URI.
+    """
+    parsed_uri = parse.urlparse(uri)
+    scheme, authority, path = parsed_uri.scheme, parsed_uri.netloc, parsed_uri.path
+
+    is_valid_scheme(scheme)
+    pkg_name, pkg_version = parse_path(path)
+    is_valid_authority(authority)
+    is_valid_package_name(pkg_name)
+    is_valid_semver(pkg_version)
+
+    return True

--- a/ethpm/utils/registry.py
+++ b/ethpm/utils/registry.py
@@ -1,48 +1,10 @@
-from urllib import parse
-
-from typing import List
-
-from ethpm.exceptions import UriNotSupportedError
-
-from ethpm.validation import (
-    validate_package_name,
-    validate_registry_uri_authority,
-    validate_registry_uri_scheme,
-    validate_registry_uri_version,
-)
-
-
-def is_ens_domain(auth: str) -> bool:
+def is_ens_domain(authority: str) -> bool:
     """
-    Returns false if URI authority is not a valid ENS domain.
+    Return false if authority is not a valid ENS domain.
     """
-    if auth[-4:] != '.eth' or len(auth.split('.')) not in [2, 3]:
+    # check that authority ends with the tld '.eth'
+    # check that there are either 2 or 3 subdomains in the authority
+    # i.e. zeppelinos.eth or packages.zeppelinos.eth
+    if authority[-4:] != '.eth' or len(authority.split('.')) not in [2, 3]:
         return False
     return True
-
-
-def is_registry_uri(uri: str) -> bool:
-    """
-    Returns True if URI is a valid registry URI.
-    Raises UriNotSupportedError if URI is an invalid URI.
-    """
-    parsed_uri = parse.urlparse(uri)
-    scheme, authority, path = parsed_uri.scheme, parsed_uri.netloc, parsed_uri.path
-
-    validate_registry_uri_scheme(scheme)
-    pkg_name, pkg_version = parse_path(path)
-    validate_registry_uri_authority(authority)
-    validate_registry_uri_version(pkg_version)
-    validate_package_name(pkg_name)
-
-    return True
-
-
-def parse_path(path: str) -> List[str]:
-    """
-    Raises exception if path is empty string.
-    If path is valid, return the name and version
-    """
-    if len(path.split('/')) not in [2, 3, 4]:
-        raise UriNotSupportedError('{0} is not a valid registry URI path.'.format(path))
-    return path.split('/')[1:3]

--- a/ethpm/utils/registry.py
+++ b/ethpm/utils/registry.py
@@ -1,28 +1,15 @@
-import re
-import semver
-
 from urllib import parse
 
 from typing import List
 
-from eth_utils import (
-    is_hex_address,
-)
-
 from ethpm.exceptions import UriNotSupportedError
 
-
-# TODO: update with correct scheme once ERC is completed
-REGISTRY_URI_SCHEME = 'ercxxx'
-PACKAGE_NAME_REGEX = '[a-zA-Z][-_a-zA-Z0-9]{0,255}'
-
-
-def is_valid_authority(auth: str) -> None:
-    """
-    Raises exception if authority is not a valid ENS domain or contract address.
-    """
-    if is_ens_domain(auth) is False and not is_hex_address(auth):
-        raise UriNotSupportedError('{0} is not a valid registry URI authority.'.format(auth))
+from ethpm.validation import (
+    validate_package_name,
+    validate_registry_uri_authority,
+    validate_registry_uri_scheme,
+    validate_registry_uri_version,
+)
 
 
 def is_ens_domain(auth: str) -> bool:
@@ -34,42 +21,6 @@ def is_ens_domain(auth: str) -> bool:
     return True
 
 
-def is_valid_semver(pkg_version: str) -> None:
-    """
-    Raises exception if package version is not valid semver.
-    """
-    try:
-        semver.parse(pkg_version)
-    except ValueError as exc:
-        raise UriNotSupportedError('{0} is not a valid registry URI version.'.format(pkg_version))
-
-
-def is_valid_package_name(pkg_name: str) -> None:
-    """
-    Returns boolean if the value is a valid package name.
-    """
-    if not bool(re.match(PACKAGE_NAME_REGEX, pkg_name)):
-        raise UriNotSupportedError('{0} is not a valid package name.'.format(pkg_name))
-
-
-def is_valid_scheme(scheme: str) -> None:
-    """
-    Raises exception is package scheme is not a valid scheme.
-    """
-    if scheme != REGISTRY_URI_SCHEME:
-        raise UriNotSupportedError('{0} is not a valid registry URI scheme.'.format(scheme))
-
-
-def parse_path(path: str) -> List[str]:
-    """
-    Raises exception if path is not a valid path.
-    If path is valid, return the name and version
-    """
-    if not path:
-        raise UriNotSupportedError('{0} is not a valid registry URI path.'.format(path))
-    return path.split('/')[1:3]
-
-
 def is_registry_uri(uri: str) -> bool:
     """
     Returns True if URI is a valid registry URI.
@@ -78,10 +29,20 @@ def is_registry_uri(uri: str) -> bool:
     parsed_uri = parse.urlparse(uri)
     scheme, authority, path = parsed_uri.scheme, parsed_uri.netloc, parsed_uri.path
 
-    is_valid_scheme(scheme)
+    validate_registry_uri_scheme(scheme)
     pkg_name, pkg_version = parse_path(path)
-    is_valid_authority(authority)
-    is_valid_package_name(pkg_name)
-    is_valid_semver(pkg_version)
+    validate_registry_uri_authority(authority)
+    validate_registry_uri_version(pkg_version)
+    validate_package_name(pkg_name)
 
     return True
+
+
+def parse_path(path: str) -> List[str]:
+    """
+    Raises exception if path is empty string.
+    If path is valid, return the name and version
+    """
+    if len(path.split('/')) not in [2, 3, 4]:
+        raise UriNotSupportedError('{0} is not a valid registry URI path.'.format(path))
+    return path.split('/')[1:3]

--- a/ethpm/validation.py
+++ b/ethpm/validation.py
@@ -1,0 +1,43 @@
+import re
+
+from eth_utils import is_checksum_address
+
+from ethpm.constants import (
+    PACKAGE_NAME_REGEX,
+    REGISTRY_URI_SCHEME,
+)
+
+from ethpm.exceptions import UriNotSupportedError
+
+
+def validate_package_name(pkg_name: str) -> None:
+    """
+    Raises exception if the value is not a valid package name.
+    """
+    if not bool(re.match(PACKAGE_NAME_REGEX, pkg_name)):
+        raise UriNotSupportedError('{0} is not a valid package name.'.format(pkg_name))
+
+
+def validate_registry_uri_authority(auth: str) -> None:
+    """
+    Raises exception if authority is not a valid ENS domain or valid checksummed contract address.
+    """
+    from ethpm.utils.registry import is_ens_domain
+    if is_ens_domain(auth) is False and not is_checksum_address(auth):
+        raise UriNotSupportedError('{0} is not a valid registry URI authority.'.format(auth))
+
+
+def validate_registry_uri_scheme(scheme: str) -> None:
+    """
+    Raises exception if package scheme is not a valid registry URI scheme.
+    """
+    if scheme != REGISTRY_URI_SCHEME:
+        raise UriNotSupportedError('{0} is not a valid registry URI scheme.'.format(scheme))
+
+
+def validate_registry_uri_version(pkg_version: str) -> None:
+    """
+    Raises exception if package version is an empty string.
+    """
+    if not pkg_version:
+        raise UriNotSupportedError('{0} is not a valid registry URI version.'.format(pkg_version))

--- a/ethpm/validation.py
+++ b/ethpm/validation.py
@@ -1,5 +1,7 @@
 import re
 
+from urllib import parse
+
 from eth_utils import is_checksum_address
 
 from ethpm.constants import (
@@ -9,35 +11,54 @@ from ethpm.constants import (
 
 from ethpm.exceptions import UriNotSupportedError
 
+from ethpm.utils.registry import (
+    is_ens_domain,
+)
+
 
 def validate_package_name(pkg_name: str) -> None:
     """
-    Raises exception if the value is not a valid package name.
+    Raise an exception if the value is not a valid package name
+    as defined in the EthPM-Spec.
     """
     if not bool(re.match(PACKAGE_NAME_REGEX, pkg_name)):
         raise UriNotSupportedError('{0} is not a valid package name.'.format(pkg_name))
 
 
+def validate_registry_uri(uri: str) -> None:
+    """
+    Raise an exception if the URI does not conform to the registry URI scheme.
+    """
+    parsed = parse.urlparse(uri)
+    scheme, authority, pkg_name, query = parsed.scheme, parsed.netloc, parsed.path, parsed.query
+    validate_registry_uri_scheme(scheme)
+
+    validate_registry_uri_authority(authority)
+    if query:
+        validate_registry_uri_version(query)
+    validate_package_name(pkg_name[1:])
+
+
 def validate_registry_uri_authority(auth: str) -> None:
     """
-    Raises exception if authority is not a valid ENS domain or valid checksummed contract address.
+    Raise an exception if the authority is not a valid ENS domain
+    or a valid checksummed contract address.
     """
-    from ethpm.utils.registry import is_ens_domain
     if is_ens_domain(auth) is False and not is_checksum_address(auth):
         raise UriNotSupportedError('{0} is not a valid registry URI authority.'.format(auth))
 
 
 def validate_registry_uri_scheme(scheme: str) -> None:
     """
-    Raises exception if package scheme is not a valid registry URI scheme.
+    Raise an exception if the scheme is not the valid registry URI scheme ('ercXXX').
     """
     if scheme != REGISTRY_URI_SCHEME:
         raise UriNotSupportedError('{0} is not a valid registry URI scheme.'.format(scheme))
 
 
-def validate_registry_uri_version(pkg_version: str) -> None:
+def validate_registry_uri_version(query: str) -> None:
     """
-    Raises exception if package version is an empty string.
+    Raise an exception if the version param is malformed.
     """
-    if not pkg_version:
-        raise UriNotSupportedError('{0} is not a valid registry URI version.'.format(pkg_version))
+    if 'version=' != query[:8]:
+        raise UriNotSupportedError('{0} is not a correctly formatted version param.'.format(query))

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'py-evm==0.2.0a18',
         'py-solc>=2.1.0,<3',
         'rlp>=1.0.1,<2',
+        'semver>=2.8.0,<3',
         'web3>=4.2.1,<5',
     ],
     setup_requires=['setuptools-markdown'],

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         'py-evm==0.2.0a18',
         'py-solc>=2.1.0,<3',
         'rlp>=1.0.1,<2',
-        'semver>=2.8.0,<3',
         'web3>=4.2.1,<5',
     ],
     setup_requires=['setuptools-markdown'],

--- a/tests/ethpm/utils/test_registry_utils.py
+++ b/tests/ethpm/utils/test_registry_utils.py
@@ -1,0 +1,67 @@
+import pytest
+
+from ethpm.exceptions import UriNotSupportedError
+
+from ethpm.utils.registry import (
+    is_registry_uri,
+)
+
+
+@pytest.mark.parametrize(
+    'uri,expected',
+    (
+        ('ercXXX://packages.zeppelinos.eth/erc20/1.0.0', True),
+        ('ercXXX://packages.zeppelinos.eth/erc20/1.0.0/', True),
+        ('ercXXX://zeppelinos.eth/erc20/1.0.0', True),
+        ('ercXXX://zeppelinos.eth/erc20/1.0.0/', True),
+        ('ercXXX://d3cda913deb6f67967b99d67acdfa1712c293601/erc20/1.0.0', True),
+        ('ercXXX://d3cda913deb6f67967b99d67acdfa1712c293601/erc20/1.0.0/', True),
+        ('ercXXX://0xd3cda913deb6f67967b99d67acdfa1712c293601/erc20/1.0.0', True),
+        ('ercXXX://0xd3cda913deb6f67967b99d67acdfa1712c293601/erc20/1.0.0/', True),
+    )
+)
+def test_is_registry_uri_validates(uri, expected):
+    assert is_registry_uri(uri) is expected
+
+
+@pytest.mark.parametrize(
+    'uri',
+    (
+        # invalid authority
+        ('ercXXX://packages.zeppelinos.com/erc20/1.0.0'),
+        ('ercXXX://package.manager.zeppelinos.eth/erc20/1.0.0'),
+        ('ercXXX://packageszeppelinoseth/erc20/1.0.0'),
+        ('ercXXX://0x12345/erc20/1.0.0'),
+        # invalid package name
+        ('ercXXX://packages.zeppelinos.eth//'),
+        ('ercXXX://packages.zeppelinos.eth///'),
+        ('ercXXX://packages.zeppelinos.eth//1.0.0'),
+        ('ercXXX://packages.zeppelinos.eth/!rc20/1.0.0'),
+        # invalid versions
+        ('ercXXX://packages.zeppelinos.eth/erc20/'),
+        ('ercXXX://packages.zeppelinos.eth/erc20//'),
+        ('ercXXX://packages.zeppelinos.eth/erc20/v1.0.0'),
+        ('ercXXX://packages.zeppelinos.eth/erc20/v1.0.0/'),
+        ('ercXXX://packages.zeppelinos.eth/erc20/version_one/'),
+        # malformed
+        ('ercXXX:packages.zeppelinos.eth/erc20/1.0.0'),
+        ('ercXXX:packages.zeppelinos.eth/erc20/1.0.0/'),
+        ('ercXXX:/packages.zeppelinos.eth/erc20/1.0.0'),
+        ('ercXXX:/packages.zeppelinos.eth/erc20/1.0.0/'),
+        ('ercXXX/packages.zeppelinos.eth/erc20/1.0.0'),
+        ('ercXXX//packages.zeppelinos.eth/erc20/1.0.0'),
+        ('ercXXXpackages.zeppelinos.eth/erc20/1.0.0'),
+        # wrong scheme
+        ('http://packages.zeppelinos.eth/erc20/1.0.0'),
+        ('ercXX://packages.zeppelinos.eth/erc20/1.0.0'),
+        # no path
+        ('ercXXX://'),
+        # weird values
+        (b'ercXXX://zeppelinos.eth/erc20/1.0.0'),
+        ('1234'),
+        ({}),
+    )
+)
+def test_is_registry_uri_raises_exception_for_invalid_uris(uri):
+    with pytest.raises(UriNotSupportedError):
+        is_registry_uri(uri)

--- a/tests/ethpm/utils/test_registry_utils.py
+++ b/tests/ethpm/utils/test_registry_utils.py
@@ -14,10 +14,8 @@ from ethpm.utils.registry import (
         ('ercXXX://packages.zeppelinos.eth/erc20/1.0.0/', True),
         ('ercXXX://zeppelinos.eth/erc20/1.0.0', True),
         ('ercXXX://zeppelinos.eth/erc20/1.0.0/', True),
-        ('ercXXX://d3cda913deb6f67967b99d67acdfa1712c293601/erc20/1.0.0', True),
-        ('ercXXX://d3cda913deb6f67967b99d67acdfa1712c293601/erc20/1.0.0/', True),
-        ('ercXXX://0xd3cda913deb6f67967b99d67acdfa1712c293601/erc20/1.0.0', True),
-        ('ercXXX://0xd3cda913deb6f67967b99d67acdfa1712c293601/erc20/1.0.0/', True),
+        ('ercXXX://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20/1.0.0', True),
+        ('ercXXX://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20/1.0.0/', True),
     )
 )
 def test_is_registry_uri_validates(uri, expected):
@@ -31,7 +29,7 @@ def test_is_registry_uri_validates(uri, expected):
         ('ercXXX://packages.zeppelinos.com/erc20/1.0.0'),
         ('ercXXX://package.manager.zeppelinos.eth/erc20/1.0.0'),
         ('ercXXX://packageszeppelinoseth/erc20/1.0.0'),
-        ('ercXXX://0x12345/erc20/1.0.0'),
+        ('ercXXX://0xd3cda913deb6f67967b99d67acdfa1712c293601/erc20/1.0.0'),
         # invalid package name
         ('ercXXX://packages.zeppelinos.eth//'),
         ('ercXXX://packages.zeppelinos.eth///'),
@@ -40,9 +38,6 @@ def test_is_registry_uri_validates(uri, expected):
         # invalid versions
         ('ercXXX://packages.zeppelinos.eth/erc20/'),
         ('ercXXX://packages.zeppelinos.eth/erc20//'),
-        ('ercXXX://packages.zeppelinos.eth/erc20/v1.0.0'),
-        ('ercXXX://packages.zeppelinos.eth/erc20/v1.0.0/'),
-        ('ercXXX://packages.zeppelinos.eth/erc20/version_one/'),
         # malformed
         ('ercXXX:packages.zeppelinos.eth/erc20/1.0.0'),
         ('ercXXX:packages.zeppelinos.eth/erc20/1.0.0/'),

--- a/tests/ethpm/utils/test_registry_utils.py
+++ b/tests/ethpm/utils/test_registry_utils.py
@@ -2,61 +2,69 @@ import pytest
 
 from ethpm.exceptions import UriNotSupportedError
 
-from ethpm.utils.registry import (
-    is_registry_uri,
+
+from ethpm.validation import (
+    validate_registry_uri,
 )
 
 
 @pytest.mark.parametrize(
-    'uri,expected',
+    'uri',
     (
-        ('ercXXX://packages.zeppelinos.eth/erc20/1.0.0', True),
-        ('ercXXX://packages.zeppelinos.eth/erc20/1.0.0/', True),
-        ('ercXXX://zeppelinos.eth/erc20/1.0.0', True),
-        ('ercXXX://zeppelinos.eth/erc20/1.0.0/', True),
-        ('ercXXX://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20/1.0.0', True),
-        ('ercXXX://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20/1.0.0/', True),
+        ('ercxxx://zeppelinos.eth/erc20/'),
+        ('ercXXX://zeppelinos.eth/erc20/'),
+        ('ercXXX://zeppelinos.eth/erc20//'),
+        ('ercXXX://zeppelinos.eth/erc20?version=1.0.0'),
+        ('ercXXX://zeppelinos.eth/erc20?version=1.0.0/'),
+        ('ercXXX://packages.zeppelinos.eth/erc20?version='),
+        ('ercXXX://packages.zeppelinos.eth/erc20?version=/'),
+        ('ercXXX://packages.zeppelinos.eth/erc20?version=1.0.0'),
+        ('ercXXX://packages.zeppelinos.eth/erc20?version=1.0.0/'),
+        ('ercXXX://packages.ethereum.eth/greeter?version=%3E%3D1.0.2%2C%3C2'),
+        ('ercXXX://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20?version=1.0.0'),
+        ('ercXXX://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20?version=1.0.0/'),
     )
 )
-def test_is_registry_uri_validates(uri, expected):
-    assert is_registry_uri(uri) is expected
+def test_is_registry_uri_validates(uri):
+    assert validate_registry_uri(uri) is None
 
 
 @pytest.mark.parametrize(
     'uri',
     (
         # invalid authority
-        ('ercXXX://packages.zeppelinos.com/erc20/1.0.0'),
-        ('ercXXX://package.manager.zeppelinos.eth/erc20/1.0.0'),
-        ('ercXXX://packageszeppelinoseth/erc20/1.0.0'),
-        ('ercXXX://0xd3cda913deb6f67967b99d67acdfa1712c293601/erc20/1.0.0'),
+        ('ercXXX://packages.zeppelinos.com/erc20?version=1.0.0'),
+        ('ercXXX://package.manager.zeppelinos.eth/erc20?version=1.0.0'),
+        ('ercXXX://packageszeppelinoseth/erc20?version=1.0.0'),
+        ('ercXXX://0xd3cda913deb6f67967b99d67acdfa1712c293601/erc20?version=1.0.0'),
         # invalid package name
-        ('ercXXX://packages.zeppelinos.eth//'),
+        ('ercXXX://packages.zeppelinos.eth/'),
         ('ercXXX://packages.zeppelinos.eth///'),
-        ('ercXXX://packages.zeppelinos.eth//1.0.0'),
-        ('ercXXX://packages.zeppelinos.eth/!rc20/1.0.0'),
-        # invalid versions
-        ('ercXXX://packages.zeppelinos.eth/erc20/'),
-        ('ercXXX://packages.zeppelinos.eth/erc20//'),
+        ('ercXXX://packages.zeppelinos.eth/?version=1.0.0'),
+        ('ercXXX://packages.zeppelinos.eth/!rc20?version=1.0.0'),
+        # invalid version param
+        ('ercXXX://zeppelinos.eth/erc20?versions=1.0.0'),
+        ('ercXXX://zeppelinos.eth/erc20?version1.0.0'),
         # malformed
-        ('ercXXX:packages.zeppelinos.eth/erc20/1.0.0'),
-        ('ercXXX:packages.zeppelinos.eth/erc20/1.0.0/'),
-        ('ercXXX:/packages.zeppelinos.eth/erc20/1.0.0'),
-        ('ercXXX:/packages.zeppelinos.eth/erc20/1.0.0/'),
-        ('ercXXX/packages.zeppelinos.eth/erc20/1.0.0'),
-        ('ercXXX//packages.zeppelinos.eth/erc20/1.0.0'),
-        ('ercXXXpackages.zeppelinos.eth/erc20/1.0.0'),
+        ('ercXXXpackageszeppelinosetherc20version1.0.0'),
+        ('ercXXX:packages.zeppelinos.eth/erc20?version=1.0.0'),
+        ('ercXXX:packages.zeppelinos.eth/erc20?version=1.0.0/'),
+        ('ercXXX:/packages.zeppelinos.eth/erc20?version=1.0.0'),
+        ('ercXXX:/packages.zeppelinos.eth/erc20?version=1.0.0/'),
+        ('ercXXX/packages.zeppelinos.eth/erc20?version=1.0.0'),
+        ('ercXXX//packages.zeppelinos.eth/erc20?version=1.0.0'),
+        ('ercXXXpackages.zeppelinos.eth/erc20?version=1.0.0'),
         # wrong scheme
-        ('http://packages.zeppelinos.eth/erc20/1.0.0'),
-        ('ercXX://packages.zeppelinos.eth/erc20/1.0.0'),
+        ('http://packages.zeppelinos.eth/erc20?version=1.0.0'),
+        ('ercXX://packages.zeppelinos.eth/erc20?version=1.0.0'),
         # no path
         ('ercXXX://'),
         # weird values
-        (b'ercXXX://zeppelinos.eth/erc20/1.0.0'),
+        (b'ercXXX://zeppelinos.eth/erc20?version=1.0.0'),
         ('1234'),
         ({}),
     )
 )
 def test_is_registry_uri_raises_exception_for_invalid_uris(uri):
     with pytest.raises(UriNotSupportedError):
-        is_registry_uri(uri)
+        validate_registry_uri(uri)


### PR DESCRIPTION
### What was wrong?
Fetching a manifest content-addressed URI from a package requires a registry URI scheme. These are the utils to validate whether or not a URI has been properly formatted. 

### How was it fixed?
A lot of the rules imposed here are followed by convention set by the dependent libraries. 
i.e.
- enforcing "://" to follow the `scheme` is convention set in `urllib`

* Using `ercxxx` as the scheme will be updated once the registry contract standard makes it's way through the ERC process


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/41689296-2ac5d420-74ad-11e8-885a-747076946e8b.png)
