### PR TITLE
Pluggable URI & IPFS backend class

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The `Package` class should provide access to the full dependency tree.
 git submodule init
 ```
 
+
 ## Registry URI 
 
 The URI to lookup a package from a registry should follow the following format. (subject to change as the Registry Contract Standard makes it's way through the EIP process)
@@ -134,6 +135,15 @@ scheme://authority/package-name?version=x.x.x
 * `version`: The URI escaped version string, *should* conform to the [semver](http://semver.org/) version numbering specification.
 
 i.e. `ercxxx://packages.zeppelinos.eth/owned?version=1.0.0`
+
+
+## URI Backend Class
+* URI Backend Class defaults to `ethpm.backends.ipfs.IFPSGatewayBackend`
+* URI Backend Class is configurable via the environment variable `ETHPM_URI_BACKEND_CLASS` set to a dotted module path
+* `DummyIPFSBackend` is used to avoid http requests within testing
+	* Can accept both a ...
+		* Valid IPFS URI -> `safe-math-lib` manifest
+		* Path to existing manifest/contract in `V2_PACKAGES_DIR` -> defined manifest/contract 
 
 
 ## Release setup

--- a/ethpm/backends/__init__.py
+++ b/ethpm/backends/__init__.py
@@ -2,15 +2,11 @@ import os
 
 from typing import Type
 
-from ethpm.backends.base import (
-    BaseURIBackend,
-)
-from ethpm.utils.module_loading import (
-    import_string,
-)
+from ethpm.backends.base import BaseURIBackend
+from ethpm.utils.module_loading import import_string
 
 
-DEFAULT_URI_BACKEND = 'ethpm.backends.ipfs.IPFSGatewayBackend'
+DEFAULT_URI_BACKEND = "ethpm.backends.ipfs.IPFSGatewayBackend"
 
 
 def get_uri_backend(import_path: str = None) -> BaseURIBackend:
@@ -23,8 +19,5 @@ def get_uri_backend(import_path: str = None) -> BaseURIBackend:
 
 def get_uri_backend_class(import_path: str = None) -> Type[BaseURIBackend]:
     if import_path is None:
-        import_path = os.environ.get(
-            'ETHPM_URI_BACKEND_CLASS',
-            DEFAULT_URI_BACKEND,
-        )
+        import_path = os.environ.get("ETHPM_URI_BACKEND_CLASS", DEFAULT_URI_BACKEND)
     return import_string(import_path)

--- a/ethpm/backends/__init__.py
+++ b/ethpm/backends/__init__.py
@@ -1,0 +1,30 @@
+import os
+
+from typing import Type
+
+from ethpm.backends.base import (
+    BaseURIBackend,
+)
+from ethpm.utils.module_loading import (
+    import_string,
+)
+
+
+DEFAULT_URI_BACKEND = 'ethpm.backends.ipfs.IPFSGatewayBackend'
+
+
+def get_uri_backend(import_path: str = None) -> BaseURIBackend:
+    """
+    Return the `BaseURIBackend` class specified by import_path, default, or env variable.
+    """
+    backend_class = get_uri_backend_class(import_path)
+    return backend_class()
+
+
+def get_uri_backend_class(import_path: str = None) -> Type[BaseURIBackend]:
+    if import_path is None:
+        import_path = os.environ.get(
+            'ETHPM_URI_BACKEND_CLASS',
+            DEFAULT_URI_BACKEND,
+        )
+    return import_string(import_path)

--- a/ethpm/backends/base.py
+++ b/ethpm/backends/base.py
@@ -1,37 +1,34 @@
-from abc import ABC, abstractmethod
+from abc import (
+    ABC,
+    abstractmethod,
+)
 
-from ethpm.utils.ipfs import extract_ipfs_path_from_uri
 
-
-# generic backend that all URI backends come from
 class BaseURIBackend(ABC):
-    def can_handle_uri(self, uri) -> bool:
-        """
-        Returns bool for whether this backend class can handle the given URI.
-        """
-        pass
+    """
+    Generic backend that all URI backends are subclassed from.
 
-    def fetch_uri_contents(uri):
+    All subclasses must implement:
+    can_handle_uri, fetch_uri_contents, base_uri
+    """
+    @abstractmethod
+    def can_handle_uri(self, uri: str) -> bool:
+        """
+        Return a bool indicating whether this backend class can handle the given URI.
+        """
+        raise NotImplementedError("Must be implemented by subclass.")
+
+    @abstractmethod
+    def fetch_uri_contents(self, uri: str) -> bytes:
         """
         Fetch the contents stored at a URI.
         """
-        pass
+        raise NotImplementedError("Must be implemented by subclass.")
 
-
-# glue code in the core logic that fetches URIS
-def get_backends_for_uri(backends, uri):
-    return tuple(backend for backend in backends if backend.can_handle_uri(uri))
-
-
-# and then some code to loop over the *good* backends and return the fetched contents
-# maybe an exception that the backends can raise if for some reason they find that can't handle it
-def get_uri_contents(): 
-    for backend in good_backends:
-        try:
-            contents = backend.fetch_uri_contents(uri)
-        except CannotHandleURI: # custom exception
-            continue
-        else:
-            return contents
-    else:
-        raise SomethingError("No backends were able to fetch the URI contents")
+    @property
+    @abstractmethod
+    def base_uri(self) -> str:
+        """
+        Return the base URI unique to a particular scheme.
+        """
+        raise NotImplementedError("Must be implemented by subclass.")

--- a/ethpm/backends/base.py
+++ b/ethpm/backends/base.py
@@ -1,7 +1,4 @@
-from abc import (
-    ABC,
-    abstractmethod,
-)
+from abc import ABC, abstractmethod
 
 
 class BaseURIBackend(ABC):
@@ -9,26 +6,19 @@ class BaseURIBackend(ABC):
     Generic backend that all URI backends are subclassed from.
 
     All subclasses must implement:
-    can_handle_uri, fetch_uri_contents, base_uri
+    can_handle_uri, fetch_uri_contents
     """
+
     @abstractmethod
     def can_handle_uri(self, uri: str) -> bool:
         """
         Return a bool indicating whether this backend class can handle the given URI.
         """
-        raise NotImplementedError("Must be implemented by subclass.")
+        pass
 
     @abstractmethod
     def fetch_uri_contents(self, uri: str) -> bytes:
         """
         Fetch the contents stored at a URI.
         """
-        raise NotImplementedError("Must be implemented by subclass.")
-
-    @property
-    @abstractmethod
-    def base_uri(self) -> str:
-        """
-        Return the base URI unique to a particular scheme.
-        """
-        raise NotImplementedError("Must be implemented by subclass.")
+        pass

--- a/ethpm/backends/base.py
+++ b/ethpm/backends/base.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+
+from ethpm.utils.ipfs import extract_ipfs_path_from_uri
+
+
+# generic backend that all URI backends come from
+class BaseURIBackend(ABC):
+    def can_handle_uri(self, uri) -> bool:
+        """
+        Returns bool for whether this backend class can handle the given URI.
+        """
+        pass
+
+    def fetch_uri_contents(uri):
+        """
+        Fetch the contents stored at a URI.
+        """
+        pass
+
+
+# glue code in the core logic that fetches URIS
+def get_backends_for_uri(backends, uri):
+    return tuple(backend for backend in backends if backend.can_handle_uri(uri))
+
+
+# and then some code to loop over the *good* backends and return the fetched contents
+# maybe an exception that the backends can raise if for some reason they find that can't handle it
+def get_uri_contents(): 
+    for backend in good_backends:
+        try:
+            contents = backend.fetch_uri_contents(uri)
+        except CannotHandleURI: # custom exception
+            continue
+        else:
+            return contents
+    else:
+        raise SomethingError("No backends were able to fetch the URI contents")

--- a/ethpm/backends/ipfs.py
+++ b/ethpm/backends/ipfs.py
@@ -1,0 +1,80 @@
+import json
+import requests
+
+from abc import abstractmethod
+
+from ethpm import V2_PACKAGES_DIR
+
+from ethpm.backends.base import BaseURIBackend
+
+from ethpm.utils.ipfs import (
+    extract_ipfs_path_from_uri,
+    is_ipfs_uri,
+)
+
+
+class BaseIPFSBackend(BaseURIBackend):
+    @abstractmethod
+    def fetch_ipfs_uri(self, uri: str) -> str:  # or maybe bytes?
+        """
+        Return the file contents stored at the URI.
+        """
+        pass
+
+
+    @abstractmethod
+    def can_handle_uri(self, uri: str) -> bool: 
+        """
+        Return a bool indicating whether or not this backend
+        is capable of serving the content at the URI.
+        """
+        return False
+
+
+class IPFSOverHTTPBackend(BaseIPFSBackend):
+
+    @property
+    def base_uri(self):
+        raise AttributeError('Base URI needs to be set by subclass')
+
+    def fetch_ipfs_uri(self, uri):  # , uri):
+        ipfs_hash = extract_ipfs_path_from_uri(uri)
+        gateway_uri = self.base_uri + ipfs_hash
+        response = requests.get(gateway_uri)
+        return response.content
+    
+    def can_handle_uri(self, uri: str) -> bool:
+        if not is_ipfs_uri(uri):
+            return False
+        return True
+
+
+IPFS_GATEWAY_PREFIX = 'https://gateway.ipfs.io/ipfs/'
+INFURA_GATEWAY_PREFIX = 'https://ipfs.infura.io/ipfs/'
+
+
+class IPFSGatewayBackend(IPFSOverHTTPBackend):
+    @property
+    def base_uri(self):
+        return IPFS_GATEWAY_PREFIX
+
+
+class InfuraIPFSBackend(IPFSOverHTTPBackend):
+    @property
+    def base_uri(self):
+        return INFURA_GATEWAY_PREFIX
+
+
+# returns locally stored manifes
+class DummyIPFSBackend(BaseIPFSBackend):
+    def fetch_ipfs_uri(self):
+        with open(str(V2_PACKAGES_DIR / 'owned' / '1.0.0.json')) as file_obj:
+            return json.load(file_obj)
+
+    def can_handle_uri(self):
+        pass
+
+
+# knows how to connect to a locally running IPFS node
+class LocalIPFSBackend(BaseIPFSBackend):
+    pass

--- a/ethpm/constants.py
+++ b/ethpm/constants.py
@@ -2,3 +2,7 @@
 REGISTRY_URI_SCHEME = "ercxxx"
 
 PACKAGE_NAME_REGEX = "[a-zA-Z][-_a-zA-Z0-9]{0,255}"
+
+IPFS_GATEWAY_PREFIX = "https://gateway.ipfs.io/ipfs/"
+
+INFURA_GATEWAY_PREFIX = "https://ipfs.infura.io/ipfs/"

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -1,5 +1,8 @@
 from typing import Any, Dict
 
+from eth_utils import (
+    to_text,
+)
 from web3 import Web3
 from web3.eth import Contract
 
@@ -105,17 +108,18 @@ class Package(object):
     @classmethod
     def from_ipfs(cls, ipfs_uri: str) -> "Package":
         """
-        Instantiate a Package object from an IPFS uri.
-        TODO: Defaults to Infura gateway, needs extension
-        to support other gateways and local nodes
+        Instantiate and return a Package object from an IPFS URI pointing to a manifest.
         """
-        if is_ipfs_uri(ipfs_uri):
-            ipfs_path = extract_ipfs_path_from_uri(ipfs_uri)
-            package_data = fetch_ipfs_package(ipfs_path)
+        uri_backend = get_uri_backend()
+        if uri_backend.can_handle_uri(ipfs_uri):
+            raw_package_data = uri_backend.fetch_uri_contents(ipfs_uri)
+            package_data = json.loads(to_text(raw_package_data))
         else:
             raise TypeError(
-                "The Package.from_ipfs method only accepts a valid IPFS uri."
-                "{0} is not a valid IPFS uri.".format(ipfs_uri)
+                "The URI Backend: {0} cannot handle the given URI: {1}.".format(
+                    type(uri_backend).__name__,
+                    ipfs_uri,
+                )
             )
 
         return cls(package_data)

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -1,11 +1,11 @@
+import json
 from typing import Any, Dict
 
-from eth_utils import (
-    to_text,
-)
+from eth_utils import to_text
 from web3 import Web3
 from web3.eth import Contract
 
+from ethpm.backends import get_uri_backend
 from ethpm.deployments import Deployments
 from ethpm.exceptions import InsufficientAssetsError
 from ethpm.typing import ContractName
@@ -17,7 +17,6 @@ from ethpm.utils.contract import (
 )
 from ethpm.utils.deployment_validation import validate_single_matching_uri
 from ethpm.utils.filesystem import load_package_data_from_file
-from ethpm.utils.ipfs import extract_ipfs_path_from_uri, fetch_ipfs_package, is_ipfs_uri
 from ethpm.utils.manifest_validation import (
     check_for_build_dependencies,
     validate_deployments_are_present,
@@ -117,8 +116,7 @@ class Package(object):
         else:
             raise TypeError(
                 "The URI Backend: {0} cannot handle the given URI: {1}.".format(
-                    type(uri_backend).__name__,
-                    ipfs_uri,
+                    type(uri_backend).__name__, ipfs_uri
                 )
             )
 

--- a/ethpm/utils/ipfs.py
+++ b/ethpm/utils/ipfs.py
@@ -12,18 +12,16 @@ def fetch_ipfs_package(hash: str) -> Dict[str, Any]:
     response.raise_for_status()
     return response.json()
 
-
 def extract_ipfs_path_from_uri(value: str) -> str:
     parse_result = parse.urlparse(value)
 
     if parse_result.netloc:
         if parse_result.path:
-            return "".join((parse_result.netloc, parse_result.path))
+            return ''.join((parse_result.netloc, parse_result.path.rstrip('/')))
         else:
             return parse_result.netloc
     else:
-        return parse_result.path.lstrip("/")
-
+        return parse_result.path.strip('/')
 
 def is_ipfs_uri(value: str) -> bool:
     parse_result = parse.urlparse(value)

--- a/ethpm/utils/ipfs.py
+++ b/ethpm/utils/ipfs.py
@@ -1,4 +1,3 @@
-from typing import Any, Dict
 from urllib import parse
 
 INFURA_IPFS_URI_PREFIX = "https://ipfs.infura.io/ipfs/"
@@ -13,11 +12,11 @@ def extract_ipfs_path_from_uri(value: str) -> str:
 
     if parse_result.netloc:
         if parse_result.path:
-            return ''.join((parse_result.netloc, parse_result.path.rstrip('/')))
+            return "".join((parse_result.netloc, parse_result.path.rstrip("/")))
         else:
             return parse_result.netloc
     else:
-        return parse_result.path.strip('/')
+        return parse_result.path.strip("/")
 
 
 def is_ipfs_uri(value: str) -> bool:

--- a/ethpm/utils/ipfs.py
+++ b/ethpm/utils/ipfs.py
@@ -1,18 +1,14 @@
 from typing import Any, Dict
 from urllib import parse
 
-import requests
-
 INFURA_IPFS_URI_PREFIX = "https://ipfs.infura.io/ipfs/"
 
 
-def fetch_ipfs_package(hash: str) -> Dict[str, Any]:
-    package_uri = INFURA_IPFS_URI_PREFIX + hash
-    response = requests.get(package_uri)
-    response.raise_for_status()
-    return response.json()
-
 def extract_ipfs_path_from_uri(value: str) -> str:
+    """
+    Return the path from an IPFS URI.
+    Path = IPFS hash & following path.
+    """
     parse_result = parse.urlparse(value)
 
     if parse_result.netloc:
@@ -23,7 +19,11 @@ def extract_ipfs_path_from_uri(value: str) -> str:
     else:
         return parse_result.path.strip('/')
 
+
 def is_ipfs_uri(value: str) -> bool:
+    """
+    Return a bool indicating whether or not the value is a valid IPFS URI.
+    """
     parse_result = parse.urlparse(value)
     if parse_result.scheme != "ipfs":
         return False

--- a/ethpm/utils/module_loading.py
+++ b/ethpm/utils/module_loading.py
@@ -1,9 +1,5 @@
-from importlib import (
-    import_module,
-)
-from typing import (
-    Any,
-)
+from importlib import import_module
+from typing import Any
 
 
 def import_string(dotted_path: str) -> Any:
@@ -13,7 +9,7 @@ def import_string(dotted_path: str) -> Any:
     last name in the path. Raise ImportError if the import failed.
     """
     try:
-        module_path, class_name = dotted_path.rsplit('.', 1)
+        module_path, class_name = dotted_path.rsplit(".", 1)
     except ValueError:
         msg = "%s doesn't look like a module path" % dotted_path
         raise ImportError(msg)
@@ -24,5 +20,7 @@ def import_string(dotted_path: str) -> Any:
         return getattr(module, class_name)
     except AttributeError:
         msg = 'Module "%s" does not define a "%s" attribute/class' % (
-            module_path, class_name)
+            module_path,
+            class_name,
+        )
         raise ImportError(msg)

--- a/ethpm/utils/module_loading.py
+++ b/ethpm/utils/module_loading.py
@@ -1,0 +1,28 @@
+from importlib import (
+    import_module,
+)
+from typing import (
+    Any,
+)
+
+
+def import_string(dotted_path: str) -> Any:
+    """
+    Source: django.utils.module_loading
+    Import a dotted module path and return the attribute/class designated by the
+    last name in the path. Raise ImportError if the import failed.
+    """
+    try:
+        module_path, class_name = dotted_path.rsplit('.', 1)
+    except ValueError:
+        msg = "%s doesn't look like a module path" % dotted_path
+        raise ImportError(msg)
+
+    module = import_module(module_path)
+
+    try:
+        return getattr(module, class_name)
+    except AttributeError:
+        msg = 'Module "%s" does not define a "%s" attribute/class' % (
+            module_path, class_name)
+        raise ImportError(msg)

--- a/ethpm/utils/uri.py
+++ b/ethpm/utils/uri.py
@@ -17,11 +17,20 @@ def get_manifest_from_content_addressed_uri(uri: str) -> Dict[str, Any]:
     """
     parse_result = parse.urlparse(uri)
     scheme = parse_result.scheme
+    uri_backend = get_uri_backend()
 
     if scheme == IPFS_SCHEME:
-        ipfs_hash = parse_result.netloc
-        manifest_data = fetch_ipfs_package(ipfs_hash)
-        return manifest_data
+        if uri_backend.can_handle_uri(uri):
+            raw_manifest_data = uri_backend.fetch_uri_contents(uri)
+            manifest_data = to_text(raw_manifest_data)
+            return json.loads(manifest_data)
+        else:
+            raise TypeError(
+                "The URI Backend: {0} cannot handle the given URI: {1}.".format(
+                    type(uri_backend).__name__,
+                    uri,
+                )
+            )
 
     if scheme in INTERNET_SCHEMES:
         raise UriNotSupportedError("Internet URIs are not yet supported.")

--- a/ethpm/utils/uri.py
+++ b/ethpm/utils/uri.py
@@ -1,8 +1,11 @@
+import json
 from typing import Any, Dict
 from urllib import parse
 
+from eth_utils import to_text
+
+from ethpm.backends import get_uri_backend
 from ethpm.exceptions import UriNotSupportedError
-from ethpm.utils.ipfs import fetch_ipfs_package
 
 IPFS_SCHEME = "ipfs"
 
@@ -27,8 +30,7 @@ def get_manifest_from_content_addressed_uri(uri: str) -> Dict[str, Any]:
         else:
             raise TypeError(
                 "The URI Backend: {0} cannot handle the given URI: {1}.".format(
-                    type(uri_backend).__name__,
-                    uri,
+                    type(uri_backend).__name__, uri
                 )
             )
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ readme = open(os.path.join(DIR, 'README.md')).read()
 extras_require={
     'test': [
         'pytest>=3.2.1,<4',
+        'requests-mock>=1.5.0,<2',
         'tox>=1.8.0,<2',
     ],
     'lint': [

--- a/tests/ethpm/backends/test_get_uri_backend.py
+++ b/tests/ethpm/backends/test_get_uri_backend.py
@@ -1,0 +1,18 @@
+from ethpm.backends import (
+    get_uri_backend,
+)
+from ethpm.backends.ipfs import (
+    DummyIPFSBackend,
+    IPFSGatewayBackend,
+)
+
+
+def test_get_uri_backend_default():
+    backend = get_uri_backend()
+    assert isinstance(backend, IPFSGatewayBackend)
+
+
+def test_get_uri_backend_with_env_variable(monkeypatch):
+    monkeypatch.setenv('ETHPM_URI_BACKEND_CLASS', 'ethpm.backends.ipfs.DummyIPFSBackend')
+    backend = get_uri_backend()
+    assert isinstance(backend, DummyIPFSBackend)

--- a/tests/ethpm/backends/test_get_uri_backend.py
+++ b/tests/ethpm/backends/test_get_uri_backend.py
@@ -1,10 +1,5 @@
-from ethpm.backends import (
-    get_uri_backend,
-)
-from ethpm.backends.ipfs import (
-    DummyIPFSBackend,
-    IPFSGatewayBackend,
-)
+from ethpm.backends import get_uri_backend
+from ethpm.backends.ipfs import DummyIPFSBackend, IPFSGatewayBackend
 
 
 def test_get_uri_backend_default():
@@ -13,6 +8,8 @@ def test_get_uri_backend_default():
 
 
 def test_get_uri_backend_with_env_variable(monkeypatch):
-    monkeypatch.setenv('ETHPM_URI_BACKEND_CLASS', 'ethpm.backends.ipfs.DummyIPFSBackend')
+    monkeypatch.setenv(
+        "ETHPM_URI_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
+    )
     backend = get_uri_backend()
     assert isinstance(backend, DummyIPFSBackend)

--- a/tests/ethpm/backends/test_ipfs_backends.py
+++ b/tests/ethpm/backends/test_ipfs_backends.py
@@ -1,0 +1,44 @@
+import pytest
+
+from ethpm.backends.ipfs import (
+    DummyIPFSBackend,
+    InfuraIPFSBackend,
+    IPFSGatewayBackend,
+)
+
+@pytest.mark.parametrize(
+    'uri',
+    (
+        'ipfs:Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
+        'ipfs:/Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
+        'ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
+    )
+)
+def test_ipfs_gateway_backend(uri):
+    base_uri = 'https://gateway.ipfs.io/ipfs/'
+    backend = IPFSGatewayBackend()
+    assert backend.base_uri == base_uri
+    assert backend.can_handle_uri(uri) is True
+    assert backend.fetch_ipfs_uri(uri).startswith(b'pragma')
+
+
+@pytest.mark.parametrize(
+    'uri',
+    (
+        'ipfs:Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
+        'ipfs:/Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
+        'ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
+    )
+)
+def test_infura_ipfs_gateway_backend(uri):
+    base_uri = 'https://ipfs.infura.io/ipfs/'
+    backend = InfuraIPFSBackend()
+    assert backend.base_uri == base_uri
+    assert backend.can_handle_uri(uri) is True
+    assert backend.fetch_ipfs_uri(uri).startswith(b'pragma')
+
+
+def test_dummy_ipfs_backend():
+    backend = DummyIPFSBackend()
+    pkg = backend.fetch_ipfs_uri()
+    assert pkg['package_name'] == 'owned'

--- a/tests/ethpm/backends/test_ipfs_backends.py
+++ b/tests/ethpm/backends/test_ipfs_backends.py
@@ -1,34 +1,54 @@
 import json
 
-from eth_utils import (
-    to_text,
-)
+from eth_utils import to_text
 import pytest
+import requests_mock
 
-from ethpm.backends.ipfs import (
-    DummyIPFSBackend,
-    InfuraIPFSBackend,
-    IPFSGatewayBackend,
-)
+from ethpm.backends.ipfs import DummyIPFSBackend, InfuraIPFSBackend, IPFSGatewayBackend
+from ethpm.constants import INFURA_GATEWAY_PREFIX, IPFS_GATEWAY_PREFIX
 
 
 @pytest.mark.parametrize(
-    'base_uri,backend',
+    "base_uri,backend",
     (
-        ('https://gateway.ipfs.io/ipfs/', IPFSGatewayBackend()),
-        ('https://ipfs.infura.io/ipfs/', InfuraIPFSBackend()),
-    )
+        (IPFS_GATEWAY_PREFIX, IPFSGatewayBackend()),
+        (INFURA_GATEWAY_PREFIX, InfuraIPFSBackend()),
+    ),
 )
-def test_ipfs_gateway_backend(base_uri, backend):
-    uri = 'ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV'
+def test_ipfs_and_infura_gateway_backends_fetch_uri_contents(
+    base_uri, backend, safe_math_manifest
+):
+    uri = "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV"
     assert backend.base_uri == base_uri
-    assert backend.can_handle_uri(uri) is True
-    assert backend.fetch_uri_contents(uri).startswith(b'pragma')
+    with requests_mock.Mocker() as m:
+        m.get(requests_mock.ANY, text=json.dumps(safe_math_manifest))
+        contents = backend.fetch_uri_contents(uri)
+        contents_dict = json.loads(to_text(contents))
+        assert contents_dict["package_name"] == "safe-math-lib"
+
+
+@pytest.mark.parametrize(
+    "uri,expected",
+    (
+        ("ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u", True),
+        ("ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u", True),
+        ("ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u", True),
+        ("http://raw.githubusercontent.com/ethpm/py-ethpm#0x123", False),
+        ("https://raw.githubusercontent.com/ethpm/py-ethpm#0x123", False),
+        (
+            "bzz://679bde3ccb6fb911db96a0ea1586c04899c6c0cc6d3426e9ee361137b270a463",
+            False,
+        ),
+        ("ercxxx://packages.eth/owned?version=1.0.0", False),
+    ),
+)
+def test_base_ipfs_gateway_backend_correctly_handle_uri_schemes(uri, expected):
+    backend = IPFSGatewayBackend()
+    assert backend.can_handle_uri(uri) is expected
 
 
 def test_dummy_ipfs_backend():
-    backend = DummyIPFSBackend()
-    pkg = backend.fetch_uri_contents('safe-math-lib/1.0.0.json')
+    pkg = DummyIPFSBackend().fetch_uri_contents("safe-math-lib/1.0.0.json")
     mnfst = to_text(pkg)
     manifest = json.loads(mnfst)
-    assert manifest['package_name'] == 'safe-math-lib'
+    assert manifest["package_name"] == "safe-math-lib"

--- a/tests/ethpm/backends/test_ipfs_backends.py
+++ b/tests/ethpm/backends/test_ipfs_backends.py
@@ -1,3 +1,8 @@
+import json
+
+from eth_utils import (
+    to_text,
+)
 import pytest
 
 from ethpm.backends.ipfs import (
@@ -6,39 +11,24 @@ from ethpm.backends.ipfs import (
     IPFSGatewayBackend,
 )
 
-@pytest.mark.parametrize(
-    'uri',
-    (
-        'ipfs:Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
-        'ipfs:/Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
-        'ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
-    )
-)
-def test_ipfs_gateway_backend(uri):
-    base_uri = 'https://gateway.ipfs.io/ipfs/'
-    backend = IPFSGatewayBackend()
-    assert backend.base_uri == base_uri
-    assert backend.can_handle_uri(uri) is True
-    assert backend.fetch_ipfs_uri(uri).startswith(b'pragma')
-
 
 @pytest.mark.parametrize(
-    'uri',
+    'base_uri,backend',
     (
-        'ipfs:Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
-        'ipfs:/Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
-        'ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV',
+        ('https://gateway.ipfs.io/ipfs/', IPFSGatewayBackend()),
+        ('https://ipfs.infura.io/ipfs/', InfuraIPFSBackend()),
     )
 )
-def test_infura_ipfs_gateway_backend(uri):
-    base_uri = 'https://ipfs.infura.io/ipfs/'
-    backend = InfuraIPFSBackend()
+def test_ipfs_gateway_backend(base_uri, backend):
+    uri = 'ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV'
     assert backend.base_uri == base_uri
     assert backend.can_handle_uri(uri) is True
-    assert backend.fetch_ipfs_uri(uri).startswith(b'pragma')
+    assert backend.fetch_uri_contents(uri).startswith(b'pragma')
 
 
 def test_dummy_ipfs_backend():
     backend = DummyIPFSBackend()
-    pkg = backend.fetch_ipfs_uri()
-    assert pkg['package_name'] == 'owned'
+    pkg = backend.fetch_uri_contents('safe-math-lib/1.0.0.json')
+    mnfst = to_text(pkg)
+    manifest = json.loads(mnfst)
+    assert manifest['package_name'] == 'safe-math-lib'

--- a/tests/ethpm/test_package_init_from_ipfs.py
+++ b/tests/ethpm/test_package_init_from_ipfs.py
@@ -1,24 +1,13 @@
 import pytest
 
-import ethpm
 from ethpm import Package
 
 VALID_IPFS_PKG = "ipfs://QmeD2s7KaBUoGYTP1eutHBmBkMMMoycdfiyGMx2DKrWXyV"
 
 
-# mock out http req to IPFS gateway
-# `fetch_ipfs_package` returns local 'safe-math-lib` pkg
-@pytest.fixture(autouse=True)
-def mock_request(monkeypatch, safe_math_manifest):
-    def mock_fetch(x):
-        return safe_math_manifest
-
-    monkeypatch.setattr(ethpm.package, "fetch_ipfs_package", mock_fetch)
-
-
 def test_package_from_ipfs_with_valid_uri():
     package = Package.from_ipfs(VALID_IPFS_PKG)
-    assert package.name == "safe-math-lib"
+    assert package.name == "owned"
     assert isinstance(package, Package)
 
 

--- a/tests/ethpm/test_package_init_from_registry.py
+++ b/tests/ethpm/test_package_init_from_registry.py
@@ -1,19 +1,8 @@
 import pytest
 from solc import compile_source
 
-import ethpm
 from ethpm import ASSETS_DIR, Package
 from ethpm.exceptions import UriNotSupportedError
-
-
-# mock out http req to IPFS gateway
-# `fetch_ipfs_package` returns local 'owned' pkg
-@pytest.fixture(autouse=True)
-def mock_request(monkeypatch, owned_manifest):
-    def mock_fetch(x):
-        return owned_manifest
-
-    monkeypatch.setattr(ethpm.utils.uri, "fetch_ipfs_package", mock_fetch)
 
 
 @pytest.fixture()
@@ -42,12 +31,14 @@ def w3_with_registry(w3):
 
 
 def test_package_init_from_registry(w3_with_registry, monkeypatch):
-    monkeypatch.setenv('ETHPM_URI_BACKEND_CLASS', 'ethpm.backends.ipfs.IPFSGatewayBackend')
+    monkeypatch.setenv(
+        "ETHPM_URI_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
+    )
     w3, address, registry = w3_with_registry
     valid_registry_uri = "ercXXX://%s/owned?version=1.0.0" % address
     pkg = Package.from_registry(valid_registry_uri, w3)
     assert isinstance(pkg, Package)
-    assert pkg.name == "owned"
+    assert pkg.name == "safe-math-lib"
 
 
 @pytest.mark.parametrize(

--- a/tests/ethpm/test_package_init_from_registry.py
+++ b/tests/ethpm/test_package_init_from_registry.py
@@ -41,7 +41,8 @@ def w3_with_registry(w3):
     return w3, address, registry
 
 
-def test_package_init_from_registry(w3_with_registry):
+def test_package_init_from_registry(w3_with_registry, monkeypatch):
+    monkeypatch.setenv('ETHPM_URI_BACKEND_CLASS', 'ethpm.backends.ipfs.IPFSGatewayBackend')
     w3, address, registry = w3_with_registry
     valid_registry_uri = "ercXXX://%s/owned?version=1.0.0" % address
     pkg = Package.from_registry(valid_registry_uri, w3)

--- a/tests/ethpm/utils/test_ipfs_utils.py
+++ b/tests/ethpm/utils/test_ipfs_utils.py
@@ -20,15 +20,15 @@ from ethpm.utils.ipfs import extract_ipfs_path_from_uri, is_ipfs_uri
         ),
         (
             "ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
-            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u",
         ),
         (
             "ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
-            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u",
         ),
         (
             "ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
-            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u",
         ),
         (
             "ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
@@ -44,15 +44,15 @@ from ethpm.utils.ipfs import extract_ipfs_path_from_uri, is_ipfs_uri
         ),
         (
             "ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
-            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
         ),
         (
             "ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
-            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
         ),
         (
             "ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
-            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
         ),
     ),
 )

--- a/tests/ethpm/utils/test_uri_utils.py
+++ b/tests/ethpm/utils/test_uri_utils.py
@@ -7,7 +7,8 @@ from ethpm.utils.uri import get_manifest_from_content_addressed_uri
 @pytest.mark.parametrize(
     "uri,source", (("ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW", "ipfs"),)
 )
-def test_get_manifest_from_content_addressed_uris_for_supported_schemes(uri, source):
+def test_get_manifest_from_content_addressed_uris_for_supported_schemes(uri, source, monkeypatch):
+    monkeypatch.setenv('ETHPM_URI_BACKEND_CLASS', 'ethpm.backends.ipfs.DummyIPFSBackend')
     manifest = get_manifest_from_content_addressed_uri(uri)
     assert "version" in manifest
     assert "package_name" in manifest

--- a/tests/ethpm/utils/test_uri_utils.py
+++ b/tests/ethpm/utils/test_uri_utils.py
@@ -7,8 +7,12 @@ from ethpm.utils.uri import get_manifest_from_content_addressed_uri
 @pytest.mark.parametrize(
     "uri,source", (("ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW", "ipfs"),)
 )
-def test_get_manifest_from_content_addressed_uris_for_supported_schemes(uri, source, monkeypatch):
-    monkeypatch.setenv('ETHPM_URI_BACKEND_CLASS', 'ethpm.backends.ipfs.DummyIPFSBackend')
+def test_get_manifest_from_content_addressed_uris_for_supported_schemes(
+    uri, source, monkeypatch
+):
+    monkeypatch.setenv(
+        "ETHPM_URI_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
+    )
     manifest = get_manifest_from_content_addressed_uri(uri)
     assert "version" in manifest
     assert "package_name" in manifest


### PR DESCRIPTION
### What was wrong?
Pluggable backend classes were needed for easier development and testing.

### How was it fixed?
Removed existing `fetch_from_ipfs` scheme and implemented a URI backend class a la discussion in #37 

- Created `BaseURIBackend` and various subclasses according to different URI schemes

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/41946574-718830c0-7970-11e8-8933-eabd7c9f866b.png)

