### PR TITLE
Rename PyPI package to be more consistent

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras_require['dev'] = (
 )
 
 setup(
-    name='eth-pm',
+    name='ethpm',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version='0.1.0-alpha.17',
     description="""Python abstraction for ERC190 packages.""",


### PR DESCRIPTION
### What was wrong?

The PyPI package name was "eth-pm".

### How was it fixed?

Changed it to "ethpm" as was decided in an earlier conversation.

#### Cute Animal Picture

![Cute animal picture](http://4.bp.blogspot.com/-MRZX_9Le27M/TrG4gZBH_hI/AAAAAAAAH5k/_cBdR7ASNAA/s1600/Best-top-desktop-animals-wallpapers-hd-animal-wallpaper-picture-image-photo-2.jpg)
