### PR TITLE
Add black to tox lint environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * parse and validate packages
 * given a web3 instance provide access to contract factory classes
 * given a web3 instance provide access to all of the deployed contract instances for the chain that web3 is connected to.
-* validate package bytecode matches compilation output.
+* validate package bytecode matches compilation output
 * validate deployed bytecode matches compilation output
 * access to packages dependencies
 * construct new packages 

--- a/ethpm/__init__.py
+++ b/ethpm/__init__.py
@@ -5,17 +5,18 @@ from pathlib import Path
 
 
 if sys.version_info.major < 3:
-    warn_msg = ("Python 2 support will end during the first quarter of 2018"
-                "Please upgrade to Python 3"
-                "https://medium.com/@pipermerriam/dropping-python-2-support-d781e7b48160"
-                )
+    warn_msg = (
+        "Python 2 support will end during the first quarter of 2018"
+        "Please upgrade to Python 3"
+        "https://medium.com/@pipermerriam/dropping-python-2-support-d781e7b48160"
+    )
     warnings.warn(warn_msg, DeprecationWarning)
 
 
 ETHPM_DIR = Path(__file__).parent
-ASSETS_DIR = ETHPM_DIR / 'assets'
-SPEC_DIR = ASSETS_DIR / 'spec'  # type: Path
-ETHPM_SPEC_DIR = ETHPM_DIR.parent / 'ethpm-spec'
-V2_PACKAGES_DIR = ETHPM_SPEC_DIR / 'examples'
+ASSETS_DIR = ETHPM_DIR / "assets"
+SPEC_DIR = ASSETS_DIR / "spec"  # type: Path
+ETHPM_SPEC_DIR = ETHPM_DIR.parent / "ethpm-spec"
+V2_PACKAGES_DIR = ETHPM_SPEC_DIR / "examples"
 
 from .package import Package  # noqa: F401

--- a/ethpm/constants.py
+++ b/ethpm/constants.py
@@ -1,4 +1,4 @@
 # TODO update once registry standard eip has been approved
-REGISTRY_URI_SCHEME = 'ercxxx'
+REGISTRY_URI_SCHEME = "ercxxx"
 
-PACKAGE_NAME_REGEX = '[a-zA-Z][-_a-zA-Z0-9]{0,255}'
+PACKAGE_NAME_REGEX = "[a-zA-Z][-_a-zA-Z0-9]{0,255}"

--- a/ethpm/deployments.py
+++ b/ethpm/deployments.py
@@ -1,22 +1,10 @@
-from typing import (
-    Dict,
-    ItemsView,
-    List,
-)
+from typing import Dict, ItemsView, List
 
-from web3.eth import (
-    Contract,
-)
-from web3.main import (
-    Web3,
-)
+from web3.eth import Contract
+from web3.main import Web3
 
-from ethpm.exceptions import (
-    ValidationError,
-)
-from ethpm.utils.contract import (
-    validate_contract_name,
-)
+from ethpm.exceptions import ValidationError
+from ethpm.utils.contract import validate_contract_name
 
 
 class Deployments:
@@ -24,10 +12,13 @@ class Deployments:
     Deployment object to access instances of
     deployed contracts belonging to a package.
     """
-    def __init__(self,
-                 deployment_data: Dict[str, Dict[str, str]],
-                 contract_factories: Dict[str, Contract],
-                 w3: Web3) -> None:
+
+    def __init__(
+        self,
+        deployment_data: Dict[str, Dict[str, str]],
+        contract_factories: Dict[str, Contract],
+        w3: Web3,
+    ) -> None:
         self.deployment_data = deployment_data
         self.contract_factories = contract_factories
         self.w3 = w3
@@ -43,19 +34,11 @@ class Deployments:
         return self.deployment_data.get(key)
 
     def items(self) -> ItemsView[str, Dict[str, str]]:
-        item_dict = {
-            name: self.get(name)
-            for name
-            in self.deployment_data
-        }
+        item_dict = {name: self.get(name) for name in self.deployment_data}
         return item_dict.items()
 
     def values(self) -> List[Dict[str, str]]:
-        values = [
-            self.get(name)
-            for name
-            in self.deployment_data
-        ]
+        values = [self.get(name) for name in self.deployment_data]
         return values
 
     def get_contract_instance(self, contract_name: str) -> None:
@@ -64,7 +47,9 @@ class Deployments:
         after validating contract name.
         """
         self._validate_name_and_references(contract_name)
-        raise NotImplementedError("All checks passed, but get_contract_instance API not complete.")
+        raise NotImplementedError(
+            "All checks passed, but get_contract_instance API not complete."
+        )
 
     def _validate_name_and_references(self, name: str) -> None:
         validate_contract_name(name)

--- a/ethpm/exceptions.py
+++ b/ethpm/exceptions.py
@@ -2,6 +2,7 @@ class PyEthPMError(Exception):
     """
     Base class for all Py-EthPM errors.
     """
+
     pass
 
 
@@ -10,6 +11,7 @@ class InsufficientAssetsError(PyEthPMError):
     Raised when a Manifest or Package does not
     contain the required assets to do something.
     """
+
     pass
 
 
@@ -17,6 +19,7 @@ class ValidationError(PyEthPMError):
     """
     Raised when something does not pass a validation check.
     """
+
     pass
 
 
@@ -24,4 +27,5 @@ class UriNotSupportedError(ValidationError):
     """
     Raised when URI scheme does not conform to the registry URI scheme.
     """
+
     pass

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -1,59 +1,33 @@
-from typing import (
-    Any,
-    Dict,
-)
+from typing import Any, Dict
 
 from web3 import Web3
-from web3.eth import (
-    Contract,
-)
+from web3.eth import Contract
 
-from ethpm.deployments import (
-    Deployments,
-)
-from ethpm.exceptions import (
-    InsufficientAssetsError,
-)
-from ethpm.typing import (
-    ContractName,
-)
+from ethpm.deployments import Deployments
+from ethpm.exceptions import InsufficientAssetsError
+from ethpm.typing import ContractName
 from ethpm.utils.contract import (
     generate_contract_factory_kwargs,
     validate_contract_name,
     validate_minimal_contract_factory_data,
     validate_w3_instance,
 )
-from ethpm.utils.deployment_validation import (
-    validate_single_matching_uri,
-)
-from ethpm.utils.filesystem import (
-    load_package_data_from_file,
-)
-from ethpm.utils.ipfs import (
-    extract_ipfs_path_from_uri,
-    fetch_ipfs_package,
-    is_ipfs_uri,
-)
+from ethpm.utils.deployment_validation import validate_single_matching_uri
+from ethpm.utils.filesystem import load_package_data_from_file
+from ethpm.utils.ipfs import extract_ipfs_path_from_uri, fetch_ipfs_package, is_ipfs_uri
 from ethpm.utils.manifest_validation import (
     check_for_build_dependencies,
     validate_deployments_are_present,
     validate_manifest_against_schema,
     validate_manifest_deployments,
 )
-from ethpm.utils.registry import (
-    lookup_manifest_uri_located_at_registry_uri,
-)
-from ethpm.utils.uri import (
-    get_manifest_from_content_addressed_uri,
-)
-from ethpm.validation import (
-    validate_registry_uri,
-)
+from ethpm.utils.registry import lookup_manifest_uri_located_at_registry_uri
+from ethpm.utils.uri import get_manifest_from_content_addressed_uri
+from ethpm.validation import validate_registry_uri
 
 
 class Package(object):
-
-    def __init__(self, manifest: Dict[str, Any], w3: Web3=None) -> None:
+    def __init__(self, manifest: Dict[str, Any], w3: Web3 = None) -> None:
         """
         A package must be constructed with a valid manifest.
         """
@@ -77,7 +51,7 @@ class Package(object):
         """
         self.w3 = w3
 
-    def get_contract_factory(self, name: ContractName, w3: Web3=None) -> Contract:
+    def get_contract_factory(self, name: ContractName, w3: Web3 = None) -> Contract:
         """
         API to generate a contract factory class.
         """
@@ -92,7 +66,7 @@ class Package(object):
         validate_w3_instance(current_w3)
 
         try:
-            contract_data = self.package_data['contract_types'][name]
+            contract_data = self.package_data["contract_types"][name]
             validate_minimal_contract_factory_data(contract_data)
         except KeyError:
             raise InsufficientAssetsError(
@@ -110,7 +84,7 @@ class Package(object):
         return "<Package {0}=={1}>".format(name, version)
 
     @classmethod
-    def from_file(cls, file_path_or_obj: str, w3: Web3) -> 'Package':
+    def from_file(cls, file_path_or_obj: str, w3: Web3) -> "Package":
         """
         Allows users to create a Package object
         from a filepath
@@ -118,7 +92,7 @@ class Package(object):
         if isinstance(file_path_or_obj, str):
             with open(file_path_or_obj) as file_obj:
                 package_data = load_package_data_from_file(file_obj)
-        elif hasattr(file_path_or_obj, 'read') and callable(file_path_or_obj.read):
+        elif hasattr(file_path_or_obj, "read") and callable(file_path_or_obj.read):
             package_data = load_package_data_from_file(file_path_or_obj)
         else:
             raise TypeError(
@@ -129,7 +103,7 @@ class Package(object):
         return cls(package_data, w3)
 
     @classmethod
-    def from_ipfs(cls, ipfs_uri: str) -> 'Package':
+    def from_ipfs(cls, ipfs_uri: str) -> "Package":
         """
         Instantiate a Package object from an IPFS uri.
         TODO: Defaults to Infura gateway, needs extension
@@ -147,7 +121,7 @@ class Package(object):
         return cls(package_data)
 
     @classmethod
-    def from_registry(cls, registry_uri: str, w3: Web3) -> 'Package':
+    def from_registry(cls, registry_uri: str, w3: Web3) -> "Package":
         """
         Instantiate a Package object from a valid Registry URI.
         --
@@ -160,17 +134,17 @@ class Package(object):
 
     @property
     def name(self) -> str:
-        return self.package_data['package_name']
+        return self.package_data["package_name"]
 
     @property
     def version(self) -> str:
-        return self.package_data['version']
+        return self.package_data["version"]
 
     #
     # Deployments
     #
 
-    def get_deployments(self, w3: Web3=None) -> 'Deployments':
+    def get_deployments(self, w3: Web3 = None) -> "Deployments":
         """
         API to retrieve instance of deployed contract dependency.
         """
@@ -185,12 +159,10 @@ class Package(object):
 
         deployments = self.package_data["deployments"][matching_uri]
         all_contract_factories = {
-            deployment_data['contract_type']: self.get_contract_factory(
-                deployment_data['contract_type'],
-                w3
+            deployment_data["contract_type"]: self.get_contract_factory(
+                deployment_data["contract_type"], w3
             )
-            for deployment_data
-            in deployments.values()
+            for deployment_data in deployments.values()
         }
 
         return Deployments(deployments, all_contract_factories, w3)

--- a/ethpm/typing/__init__.py
+++ b/ethpm/typing/__init__.py
@@ -1,4 +1,1 @@
-from .misc import (  # noqa: F401
-    ContractName,
-    URI,
-)
+from .misc import ContractName, URI  # noqa: F401

--- a/ethpm/typing/misc.py
+++ b/ethpm/typing/misc.py
@@ -1,7 +1,5 @@
-from typing import (
-    NewType,
-)
+from typing import NewType
 
-ContractName = NewType('ContractName', str)
+ContractName = NewType("ContractName", str)
 
-URI = NewType('URI', str)
+URI = NewType("URI", str)

--- a/ethpm/utils/chains.py
+++ b/ethpm/utils/chains.py
@@ -1,28 +1,16 @@
 import re
-from typing import (
-    Tuple,
-)
-from urllib import (
-    parse,
-)
+from typing import Tuple
+from urllib import parse
 
-from cytoolz import (
-    curry,
-)
-from eth_utils import (
-    add_0x_prefix,
-    encode_hex,
-    remove_0x_prefix,
-)
+from cytoolz import curry
+from eth_utils import add_0x_prefix, encode_hex, remove_0x_prefix
 from web3 import Web3
 
-from ethpm.typing import (
-    URI,
-)
+from ethpm.typing import URI
 
 
 def get_chain_id(web3: Web3) -> str:
-    return web3.eth.getBlock(0)['hash']
+    return web3.eth.getBlock(0)["hash"]
 
 
 BLOCK = "block"
@@ -48,11 +36,7 @@ def parse_BIP122_uri(blockchain_uri: URI) -> Tuple[str, str, str]:
     if match is None:
         raise ValueError("Invalid URI format: '{0}'".format(blockchain_uri))
     chain_id, resource_type, resource_hash = match.groups()
-    return (
-        add_0x_prefix(chain_id),
-        resource_type,
-        add_0x_prefix(resource_hash),
-    )
+    return (add_0x_prefix(chain_id), resource_type, add_0x_prefix(resource_hash))
 
 
 def is_BIP122_block_uri(value: URI) -> bool:
@@ -65,9 +49,9 @@ def is_BIP122_block_uri(value: URI) -> bool:
 @curry
 def check_if_chain_matches_chain_uri(web3: Web3, blockchain_uri: URI) -> bool:
     chain_id, resource_type, resource_hash = parse_BIP122_uri(blockchain_uri)
-    genesis_block = web3.eth.getBlock('earliest')
+    genesis_block = web3.eth.getBlock("earliest")
 
-    if encode_hex(genesis_block['hash']) != chain_id:
+    if encode_hex(genesis_block["hash"]) != chain_id:
         return False
 
     if resource_type == BLOCK:
@@ -75,7 +59,7 @@ def check_if_chain_matches_chain_uri(web3: Web3, blockchain_uri: URI) -> bool:
     else:
         raise ValueError("Unsupported resource type: {0}".format(resource_type))
 
-    if encode_hex(resource['hash']) == resource_hash:
+    if encode_hex(resource["hash"]) == resource_hash:
         return True
     else:
         return False
@@ -88,25 +72,31 @@ def is_block_or_transaction_hash(value: str) -> bool:
     return bool(re.match(BLOCK_OR_TRANSACTION_HASH_REGEX, value))
 
 
-def create_BIP122_uri(chain_id: str, resource_type: str, resource_identifier: str) -> URI:
+def create_BIP122_uri(
+    chain_id: str, resource_type: str, resource_identifier: str
+) -> URI:
     """
     See: https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki
     """
     if resource_type != BLOCK:
         raise ValueError("Invalid resource_type.  Must be one of 'block'")
     elif not is_block_or_transaction_hash(resource_identifier):
-        raise ValueError("Invalid resource_identifier.  Must be a hex encoded 32 byte value")
+        raise ValueError(
+            "Invalid resource_identifier.  Must be a hex encoded 32 byte value"
+        )
     elif not is_block_or_transaction_hash(chain_id):
         raise ValueError("Invalid chain_id.  Must be a hex encoded 32 byte value")
 
-    return parse.urlunsplit([
-        'blockchain',
-        remove_0x_prefix(chain_id),
-        "{0}/{1}".format(resource_type, remove_0x_prefix(resource_identifier)),
-        '',
-        '',
-    ])
+    return parse.urlunsplit(
+        [
+            "blockchain",
+            remove_0x_prefix(chain_id),
+            "{0}/{1}".format(resource_type, remove_0x_prefix(resource_identifier)),
+            "",
+            "",
+        ]
+    )
 
 
 def create_block_uri(chain_id: str, block_identifier: str) -> URI:
-    return create_BIP122_uri(chain_id, 'block', remove_0x_prefix(block_identifier))
+    return create_BIP122_uri(chain_id, "block", remove_0x_prefix(block_identifier))

--- a/ethpm/utils/contract.py
+++ b/ethpm/utils/contract.py
@@ -1,29 +1,12 @@
 import re
-from typing import (
-    Any,
-    Dict,
-    Generator,
-    List,
-    Tuple,
-)
+from typing import Any, Dict, Generator, List, Tuple
 
-from eth_utils import (
-    encode_hex,
-    to_bytes,
-    to_dict,
-)
-from solc import (
-    compile_files,
-)
+from eth_utils import encode_hex, to_bytes, to_dict
+from solc import compile_files
 from web3 import Web3
 
-from ethpm import (
-    V2_PACKAGES_DIR,
-)
-from ethpm.exceptions import (
-    InsufficientAssetsError,
-    ValidationError,
-)
+from ethpm import V2_PACKAGES_DIR
+from ethpm.exceptions import InsufficientAssetsError, ValidationError
 
 
 def validate_minimal_contract_factory_data(contract_data: Dict[str, str]) -> None:
@@ -53,7 +36,8 @@ def validate_w3_instance(w3: Web3) -> None:
 
 @to_dict
 def generate_contract_factory_kwargs(
-        contract_data: Dict[str, Any]) -> Generator[Tuple[str, Any], None, None]:
+    contract_data: Dict[str, Any]
+) -> Generator[Tuple[str, Any], None, None]:
     """
     Build a dictionary of kwargs to be passed into contract factory.
     """
@@ -68,15 +52,12 @@ def generate_contract_factory_kwargs(
 
 
 def compile_contracts(contract_name: str, alias: str, paths: List[str]) -> str:
-    '''
+    """
     Compile multiple contracts to bytecode.
-    '''
-    bin_id = '{0}.sol:{0}'.format(contract_name)
-    contract_paths = [
-        str(V2_PACKAGES_DIR / alias / path[1:])
-        for path in paths
-    ]
+    """
+    bin_id = "{0}.sol:{0}".format(contract_name)
+    contract_paths = [str(V2_PACKAGES_DIR / alias / path[1:]) for path in paths]
     compiled_source = compile_files(contract_paths)
     bin_lookup = str(V2_PACKAGES_DIR / alias / bin_id)
-    compiled_source_bin = compiled_source[bin_lookup]['bin']
+    compiled_source_bin = compiled_source[bin_lookup]["bin"]
     return compiled_source_bin

--- a/ethpm/utils/deployment_validation.py
+++ b/ethpm/utils/deployment_validation.py
@@ -1,24 +1,15 @@
-from typing import (
-    List,
-)
+from typing import List
 
 from web3 import Web3
 
-from ethpm.exceptions import (
-    ValidationError,
-)
-from ethpm.utils.chains import (
-    check_if_chain_matches_chain_uri,
-)
+from ethpm.exceptions import ValidationError
+from ethpm.utils.chains import check_if_chain_matches_chain_uri
 
 
 def validate_single_matching_uri(all_blockchain_uris: List[str], w3: Web3) -> str:
 
     matching_uris = [
-        uri
-        for uri
-        in all_blockchain_uris
-        if check_if_chain_matches_chain_uri(w3, uri)
+        uri for uri in all_blockchain_uris if check_if_chain_matches_chain_uri(w3, uri)
     ]
 
     if not matching_uris:
@@ -26,8 +17,7 @@ def validate_single_matching_uri(all_blockchain_uris: List[str], w3: Web3) -> st
     elif len(matching_uris) != 1:
         raise ValidationError(
             "Package has too many ({0}) matching URIs: {1}.".format(
-                len(matching_uris),
-                matching_uris,
+                len(matching_uris), matching_uris
             )
         )
     return matching_uris[0]

--- a/ethpm/utils/filesystem.py
+++ b/ethpm/utils/filesystem.py
@@ -1,8 +1,5 @@
 import json
-from typing import (
-    IO,
-    Dict,
-)
+from typing import IO, Dict
 
 
 def load_package_data_from_file(file_obj: IO[str]) -> Dict[str, str]:

--- a/ethpm/utils/ipfs.py
+++ b/ethpm/utils/ipfs.py
@@ -1,10 +1,5 @@
-from typing import (
-    Any,
-    Dict,
-)
-from urllib import (
-    parse,
-)
+from typing import Any, Dict
+from urllib import parse
 
 import requests
 
@@ -23,16 +18,16 @@ def extract_ipfs_path_from_uri(value: str) -> str:
 
     if parse_result.netloc:
         if parse_result.path:
-            return ''.join((parse_result.netloc, parse_result.path))
+            return "".join((parse_result.netloc, parse_result.path))
         else:
             return parse_result.netloc
     else:
-        return parse_result.path.lstrip('/')
+        return parse_result.path.lstrip("/")
 
 
 def is_ipfs_uri(value: str) -> bool:
     parse_result = parse.urlparse(value)
-    if parse_result.scheme != 'ipfs':
+    if parse_result.scheme != "ipfs":
         return False
     if not parse_result.netloc and not parse_result.path:
         return False

--- a/ethpm/utils/manifest_validation.py
+++ b/ethpm/utils/manifest_validation.py
@@ -1,25 +1,14 @@
 import itertools
 import json
 import os
-from typing import (
-    Any,
-    Dict,
-)
+from typing import Any, Dict
 
-from jsonschema import (
-    ValidationError as jsonValidationError,
-    validate,
-)
+from jsonschema import ValidationError as jsonValidationError, validate
 
-from ethpm import (
-    SPEC_DIR,
-    V2_PACKAGES_DIR,
-)
-from ethpm.exceptions import (
-    ValidationError,
-)
+from ethpm import SPEC_DIR, V2_PACKAGES_DIR
+from ethpm.exceptions import ValidationError
 
-MANIFEST_SCHEMA_PATH = str(SPEC_DIR / 'package.spec.json')
+MANIFEST_SCHEMA_PATH = str(SPEC_DIR / "package.spec.json")
 
 
 def _load_schema_data() -> Dict[str, Any]:
@@ -56,16 +45,18 @@ def validate_manifest_deployments(manifest: Dict[str, Any]) -> None:
     if set(("contract_types", "deployments")).issubset(manifest):
         all_contract_types = list(manifest["contract_types"].keys())
         all_deployments = list(manifest["deployments"].values())
-        all_deployment_names = set(itertools.chain.from_iterable(
-            deployment
-            for deployment
-            in all_deployments
-        ))
+        all_deployment_names = set(
+            itertools.chain.from_iterable(deployment for deployment in all_deployments)
+        )
 
-        missing_contract_types = set(all_deployment_names).difference(all_contract_types)
+        missing_contract_types = set(all_deployment_names).difference(
+            all_contract_types
+        )
         if missing_contract_types:
             raise ValidationError(
-                    "Manifest missing references to contracts: {0}.".format(missing_contract_types)
+                "Manifest missing references to contracts: {0}.".format(
+                    missing_contract_types
+                )
             )
 
 
@@ -73,8 +64,10 @@ def check_for_build_dependencies(valid_manifest: Dict[str, Any]) -> None:
     """
     Catch packages that rely on other packages
     """
-    if valid_manifest.get('build_dependencies'):
-        raise NotImplementedError("Handling of build dependencies has not yet been implemented")
+    if valid_manifest.get("build_dependencies"):
+        raise NotImplementedError(
+            "Handling of build dependencies has not yet been implemented"
+        )
 
 
 def validate_manifest_exists(manifest_id: str) -> None:

--- a/ethpm/utils/registry.py
+++ b/ethpm/utils/registry.py
@@ -1,20 +1,11 @@
 import json
-from typing import (
-    Any,
-    Dict,
-)
-from urllib import (
-    parse,
-)
+from typing import Any, Dict
+from urllib import parse
 
-from eth_utils import (
-    to_bytes,
-)
+from eth_utils import to_bytes
 from web3 import Web3
 
-from ethpm import (
-    ASSETS_DIR,
-)
+from ethpm import ASSETS_DIR
 
 
 def is_ens_domain(authority: str) -> bool:
@@ -24,7 +15,7 @@ def is_ens_domain(authority: str) -> bool:
     # check that authority ends with the tld '.eth'
     # check that there are either 2 or 3 subdomains in the authority
     # i.e. zeppelinos.eth or packages.zeppelinos.eth
-    if authority[-4:] != '.eth' or len(authority.split('.')) not in [2, 3]:
+    if authority[-4:] != ".eth" or len(authority.split(".")) not in [2, 3]:
         return False
     return True
 
@@ -34,7 +25,7 @@ def fetch_standard_registry_abi() -> Dict[str, Any]:
     Return the standard Registry ABI to interact with a deployed Registry.
     TODO: Update once the standard is finalized via ERC process.
     """
-    with open(str(ASSETS_DIR / 'registry_abi.json')) as file_obj:
+    with open(str(ASSETS_DIR / "registry_abi.json")) as file_obj:
         return json.load(file_obj)
 
 
@@ -47,10 +38,7 @@ def lookup_manifest_uri_located_at_registry_uri(registry_uri: str, w3: Web3) -> 
     """
     parsed_uri = parse.urlparse(registry_uri)
     authority = parsed_uri.netloc
-    pkg_name = to_bytes(text=parsed_uri.path.strip('/'))
-    registry = w3.eth.contract(
-        address=authority,
-        abi=REGISTRY_ABI,
-    )
+    pkg_name = to_bytes(text=parsed_uri.path.strip("/"))
+    registry = w3.eth.contract(address=authority, abi=REGISTRY_ABI)
     manifest_uri = registry.functions.lookupPackage(pkg_name).call()
     return manifest_uri

--- a/ethpm/utils/uri.py
+++ b/ethpm/utils/uri.py
@@ -1,23 +1,14 @@
-from typing import (
-    Any,
-    Dict,
-)
-from urllib import (
-    parse,
-)
+from typing import Any, Dict
+from urllib import parse
 
-from ethpm.exceptions import (
-    UriNotSupportedError,
-)
-from ethpm.utils.ipfs import (
-    fetch_ipfs_package,
-)
+from ethpm.exceptions import UriNotSupportedError
+from ethpm.utils.ipfs import fetch_ipfs_package
 
-IPFS_SCHEME = 'ipfs'
+IPFS_SCHEME = "ipfs"
 
-INTERNET_SCHEMES = ['http', 'https']
+INTERNET_SCHEMES = ["http", "https"]
 
-SWARM_SCHEMES = ['bzz', 'bzz-immutable', 'bzz-raw']
+SWARM_SCHEMES = ["bzz", "bzz-immutable", "bzz-raw"]
 
 
 def get_manifest_from_content_addressed_uri(uri: str) -> Dict[str, Any]:
@@ -33,9 +24,9 @@ def get_manifest_from_content_addressed_uri(uri: str) -> Dict[str, Any]:
         return manifest_data
 
     if scheme in INTERNET_SCHEMES:
-        raise UriNotSupportedError('Internet URIs are not yet supported.')
+        raise UriNotSupportedError("Internet URIs are not yet supported.")
 
     if scheme in SWARM_SCHEMES:
-        raise UriNotSupportedError('Swarm URIs are not yet supported.')
+        raise UriNotSupportedError("Swarm URIs are not yet supported.")
 
-    raise UriNotSupportedError('The URI scheme:{0} is not supported.'.format(scheme))
+    raise UriNotSupportedError("The URI scheme:{0} is not supported.".format(scheme))

--- a/ethpm/validation.py
+++ b/ethpm/validation.py
@@ -1,22 +1,11 @@
 import re
-from urllib import (
-    parse,
-)
+from urllib import parse
 
-from eth_utils import (
-    is_checksum_address,
-)
+from eth_utils import is_checksum_address
 
-from ethpm.constants import (
-    PACKAGE_NAME_REGEX,
-    REGISTRY_URI_SCHEME,
-)
-from ethpm.exceptions import (
-    UriNotSupportedError,
-)
-from ethpm.utils.registry import (
-    is_ens_domain,
-)
+from ethpm.constants import PACKAGE_NAME_REGEX, REGISTRY_URI_SCHEME
+from ethpm.exceptions import UriNotSupportedError
+from ethpm.utils.registry import is_ens_domain
 
 
 def validate_package_name(pkg_name: str) -> None:
@@ -25,7 +14,7 @@ def validate_package_name(pkg_name: str) -> None:
     as defined in the EthPM-Spec.
     """
     if not bool(re.match(PACKAGE_NAME_REGEX, pkg_name)):
-        raise UriNotSupportedError('{0} is not a valid package name.'.format(pkg_name))
+        raise UriNotSupportedError("{0} is not a valid package name.".format(pkg_name))
 
 
 def validate_registry_uri(uri: str) -> None:
@@ -33,7 +22,12 @@ def validate_registry_uri(uri: str) -> None:
     Raise an exception if the URI does not conform to the registry URI scheme.
     """
     parsed = parse.urlparse(uri)
-    scheme, authority, pkg_name, query = parsed.scheme, parsed.netloc, parsed.path, parsed.query
+    scheme, authority, pkg_name, query = (
+        parsed.scheme,
+        parsed.netloc,
+        parsed.path,
+        parsed.query,
+    )
     validate_registry_uri_scheme(scheme)
 
     validate_registry_uri_authority(authority)
@@ -48,7 +42,9 @@ def validate_registry_uri_authority(auth: str) -> None:
     or a valid checksummed contract address.
     """
     if is_ens_domain(auth) is False and not is_checksum_address(auth):
-        raise UriNotSupportedError('{0} is not a valid registry URI authority.'.format(auth))
+        raise UriNotSupportedError(
+            "{0} is not a valid registry URI authority.".format(auth)
+        )
 
 
 def validate_registry_uri_scheme(scheme: str) -> None:
@@ -56,7 +52,9 @@ def validate_registry_uri_scheme(scheme: str) -> None:
     Raise an exception if the scheme is not the valid registry URI scheme ('ercXXX').
     """
     if scheme != REGISTRY_URI_SCHEME:
-        raise UriNotSupportedError('{0} is not a valid registry URI scheme.'.format(scheme))
+        raise UriNotSupportedError(
+            "{0} is not a valid registry URI scheme.".format(scheme)
+        )
 
 
 def validate_registry_uri_version(query: str) -> None:
@@ -64,5 +62,7 @@ def validate_registry_uri_version(query: str) -> None:
     Raise an exception if the version param is malformed.
     """
     query_dict = parse.parse_qs(query, keep_blank_values=True)
-    if 'version' not in query_dict:
-        raise UriNotSupportedError('{0} is not a correctly formatted version param.'.format(query))
+    if "version" not in query_dict:
+        raise UriNotSupportedError(
+            "{0} is not a correctly formatted version param.".format(query)
+        )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ extras_require={
         'tox>=1.8.0,<2',
     ],
     'lint': [
+        'black>=18.6b4,<19',
         'isort>=4.2.15,<5',   
         'flake8>=3.5.0,<4',
         'mypy<0.600',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,29 +3,21 @@ import json
 
 import pytest
 from web3 import Web3
-from web3.providers.eth_tester import (
-    EthereumTesterProvider,
-)
+from web3.providers.eth_tester import EthereumTesterProvider
 
-from ethpm import (
-    V2_PACKAGES_DIR,
-)
-from ethpm.utils.chains import (
-    create_block_uri,
-    get_chain_id,
-)
+from ethpm import V2_PACKAGES_DIR
+from ethpm.utils.chains import create_block_uri, get_chain_id
 
 PACKAGE_NAMES = [
-    'escrow',
-    'owned',
-    'piper-coin',
-    'safe-math-lib',
-    'standard-token',
-    'transferable',
-    'wallet-with-send',
-    'wallet',
+    "escrow",
+    "owned",
+    "piper-coin",
+    "safe-math-lib",
+    "standard-token",
+    "transferable",
+    "wallet-with-send",
+    "wallet",
 ]
-
 
 
 @pytest.fixture()
@@ -39,7 +31,7 @@ def w3():
 def all_manifests():
     manifests = []
     for pkg in PACKAGE_NAMES:
-        with open(str(V2_PACKAGES_DIR / pkg / '1.0.0.json')) as file_obj:
+        with open(str(V2_PACKAGES_DIR / pkg / "1.0.0.json")) as file_obj:
             manifest = json.load(file_obj)
             manifests.append(manifest)
     return manifests
@@ -49,25 +41,28 @@ def all_manifests():
 # should be extended to all_manifest_types asap
 @pytest.fixture
 def safe_math_manifest():
-    with open(str(V2_PACKAGES_DIR / 'safe-math-lib' / '1.0.0.json')) as file_obj:
+    with open(str(V2_PACKAGES_DIR / "safe-math-lib" / "1.0.0.json")) as file_obj:
         return json.load(file_obj)
 
 
 @pytest.fixture
 def owned_manifest():
-    with open(str(V2_PACKAGES_DIR / 'owned' / '1.0.0.json')) as file_obj:
+    with open(str(V2_PACKAGES_DIR / "owned" / "1.0.0.json")) as file_obj:
         return json.load(file_obj)
+
 
 # standalone = no `build_dependencies` which aren't fully supported yet
 @pytest.fixture
 def all_standalone_manifests(all_manifests):
-    standalone_manifests = [mnfst for mnfst in all_manifests if "build_dependencies" not in mnfst]
+    standalone_manifests = [
+        mnfst for mnfst in all_manifests if "build_dependencies" not in mnfst
+    ]
     return standalone_manifests
 
 
 @pytest.fixture()
 def invalid_manifest(safe_math_manifest):
-    safe_math_manifest['manifest_version'] = 1
+    safe_math_manifest["manifest_version"] = 1
     return safe_math_manifest
 
 
@@ -92,14 +87,14 @@ def manifest_with_matching_deployment(w3, tmpdir, safe_math_manifest):
     block = w3.eth.getBlock("earliest")
     block_uri = create_block_uri(w3.toHex(chain_id), w3.toHex(block.hash))
     manifest = copy.deepcopy(safe_math_manifest)
-    manifest["deployments"] =  {}
+    manifest["deployments"] = {}
     manifest["deployments"][block_uri] = {
-      "SafeMathLib": {
-        "contract_type": "SafeMathLib",
-        "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
-        "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
-        "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
-      }
+        "SafeMathLib": {
+            "contract_type": "SafeMathLib",
+            "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
+            "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
+            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c",
+        }
     }
     return manifest
 
@@ -107,17 +102,17 @@ def manifest_with_matching_deployment(w3, tmpdir, safe_math_manifest):
 @pytest.fixture
 def manifest_with_no_matching_deployments(w3, tmpdir, safe_math_manifest):
     w3.testing.mine(5)
-    incorrect_chain_id = (b'\x00' * 31 + b'\x01')
+    incorrect_chain_id = b"\x00" * 31 + b"\x01"
     block = w3.eth.getBlock("earliest")
     block_uri = create_block_uri(w3.toHex(incorrect_chain_id), w3.toHex(block.hash))
     manifest = copy.deepcopy(safe_math_manifest)
     manifest["deployments"][block_uri] = {
-      "SafeMathLib": {
-        "contract_type": "SafeMathLib",
-        "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
-        "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
-        "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
-      }
+        "SafeMathLib": {
+            "contract_type": "SafeMathLib",
+            "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
+            "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
+            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c",
+        }
     }
     return manifest
 
@@ -132,20 +127,20 @@ def manifest_with_multiple_matches(w3, tmpdir, safe_math_manifest):
     second_block = w3.eth.getBlock("latest")
     second_block_uri = create_block_uri(w3.toHex(chain_id), w3.toHex(second_block.hash))
     manifest = copy.deepcopy(safe_math_manifest)
-    manifest['deployments'][block_uri] = {
+    manifest["deployments"][block_uri] = {
         "SafeMathLib": {
             "contract_type": "SafeMathLib",
             "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
             "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
-            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
+            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c",
         }
     }
-    manifest['deployments'][second_block_uri] = {
+    manifest["deployments"][second_block_uri] = {
         "SafeMathLib": {
             "contract_type": "SafeMathLib",
             "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
             "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
-            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
+            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c",
         }
     }
     return manifest
@@ -154,12 +149,14 @@ def manifest_with_multiple_matches(w3, tmpdir, safe_math_manifest):
 @pytest.fixture
 def manifest_with_conflicting_deployments(tmpdir, safe_math_manifest):
     manifest = copy.deepcopy(safe_math_manifest)
-    manifest["deployments"]["blockchain://41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d/block/1e96de11320c83cca02e8b9caf3e489497e8e432befe5379f2f08599f8aecede"] = {
+    manifest["deployments"][
+        "blockchain://41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d/block/1e96de11320c83cca02e8b9caf3e489497e8e432befe5379f2f08599f8aecede"
+    ] = {
         "WrongNameLib": {
             "contract_type": "WrongNameLib",
             "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
             "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
-            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
+            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c",
         }
     }
     return manifest

--- a/tests/ethpm/test_deployments.py
+++ b/tests/ethpm/test_deployments.py
@@ -1,23 +1,17 @@
 import pytest
 
-from ethpm import (
-    Package,
-)
-from ethpm.deployments import (
-    Deployments,
-)
-from ethpm.exceptions import (
-    ValidationError,
-)
+from ethpm import Package
+from ethpm.deployments import Deployments
+from ethpm.exceptions import ValidationError
 
 DEPLOYMENT_DATA = {
-      "SafeMathLib": {
+    "SafeMathLib": {
         "contract_type": "SafeMathLib",
         "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
         "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
-        "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
-      }
+        "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c",
     }
+}
 
 
 @pytest.fixture
@@ -45,7 +39,9 @@ def test_deployment_implements_getitem(deployment):
 
 
 @pytest.mark.parametrize("name", ("", "-abc", "A=bc", "X" * 257))
-def test_deployment_getitem_with_invalid_contract_name_raises_exception(name, deployment):
+def test_deployment_getitem_with_invalid_contract_name_raises_exception(
+    name, deployment
+):
     with pytest.raises(ValidationError):
         assert deployment[name]
 
@@ -55,7 +51,9 @@ def test_deployment_getitem_without_deployment_reference_raises_exception(deploy
         deployment["DoesNotExist"]
 
 
-def test_deployment_getitem_without_contract_type_reference_raises_exception(invalid_deployment):
+def test_deployment_getitem_without_contract_type_reference_raises_exception(
+    invalid_deployment
+):
     with pytest.raises(ValidationError):
         invalid_deployment["SafeMathLib"]
 
@@ -65,7 +63,9 @@ def test_deployment_implements_get_items(deployment):
     assert deployment.items() == expected_items
 
 
-def test_deployment_get_items_with_invalid_contract_names_raises_exception(invalid_deployment):
+def test_deployment_get_items_with_invalid_contract_names_raises_exception(
+    invalid_deployment
+):
     with pytest.raises(ValidationError):
         invalid_deployment.items()
 
@@ -75,7 +75,9 @@ def test_deployment_implements_get_values(deployment):
     assert deployment.values() == expected_values
 
 
-def test_deployment_get_values_with_invalid_contract_names_raises_exception(invalid_deployment):
+def test_deployment_get_values_with_invalid_contract_names_raises_exception(
+    invalid_deployment
+):
     with pytest.raises(ValidationError):
         invalid_deployment.values()
 
@@ -85,27 +87,37 @@ def test_deployment_implements_key_lookup(deployment):
     assert key is True
 
 
-def test_deployment_implements_key_lookup_with_nonexistent_key_raises_exception(deployment):
+def test_deployment_implements_key_lookup_with_nonexistent_key_raises_exception(
+    deployment
+):
     key = "invalid" in deployment
     assert key is False
 
 
 @pytest.mark.parametrize("invalid_name", ("", "-abc", "A=bc", "X" * 257))
-def test_get_contract_instance_with_invalid_name_raises_exception(deployment, invalid_name):
+def test_get_contract_instance_with_invalid_name_raises_exception(
+    deployment, invalid_name
+):
     with pytest.raises(ValidationError):
         deployment.get_contract_instance(invalid_name)
 
 
-def test_get_contract_instance_without_reference_in_deployments_raises_exception(deployment):
+def test_get_contract_instance_without_reference_in_deployments_raises_exception(
+    deployment
+):
     with pytest.raises(KeyError):
         deployment.get_contract_instance("InvalidContract")
 
 
-def test_get_contract_instance_without_reference_in_contract_factories_raises(invalid_deployment):
+def test_get_contract_instance_without_reference_in_contract_factories_raises(
+    invalid_deployment
+):
     with pytest.raises(ValidationError):
         invalid_deployment.get_contract_instance("SafeMathLib")
 
 
-def test_get_contract_instance_correctly_configured_raises_NotImplementedError(deployment):
+def test_get_contract_instance_correctly_configured_raises_NotImplementedError(
+    deployment
+):
     with pytest.raises(NotImplementedError):
         deployment.get_contract_instance("SafeMathLib")

--- a/tests/ethpm/test_get_deployments.py
+++ b/tests/ethpm/test_get_deployments.py
@@ -1,14 +1,8 @@
 import pytest
 
-from ethpm import (
-    Package,
-)
-from ethpm.deployments import (
-    Deployments,
-)
-from ethpm.exceptions import (
-    ValidationError,
-)
+from ethpm import Package
+from ethpm.deployments import Deployments
+from ethpm.exceptions import ValidationError
 
 
 @pytest.fixture
@@ -27,25 +21,33 @@ def test_get_deployments_without_w3_arg_or_default_raises_exception(matching_pac
         matching_package.get_deployments()
 
 
-def test_get_deployments_with_empty_deployment_raise_exception(w3, manifest_with_empty_deployments):
+def test_get_deployments_with_empty_deployment_raise_exception(
+    w3, manifest_with_empty_deployments
+):
     package = Package(manifest_with_empty_deployments)
     with pytest.raises(ValidationError):
         package.get_deployments(w3)
 
 
-def test_get_deployments_with_no_deployments_raises_exception(w3, manifest_with_no_deployments):
+def test_get_deployments_with_no_deployments_raises_exception(
+    w3, manifest_with_no_deployments
+):
     package = Package(manifest_with_no_deployments)
     with pytest.raises(ValidationError):
         package.get_deployments(w3)
 
 
-def test_get_deployments_with_no_match_raises_exception(w3, manifest_with_no_matching_deployments):
+def test_get_deployments_with_no_match_raises_exception(
+    w3, manifest_with_no_matching_deployments
+):
     package = Package(manifest_with_no_matching_deployments)
     with pytest.raises(ValidationError):
         package.get_deployments(w3)
 
 
-def test_get_deployments_with_multiple_matches_raises_exception(w3, manifest_with_multiple_matches):
+def test_get_deployments_with_multiple_matches_raises_exception(
+    w3, manifest_with_multiple_matches
+):
     package = Package(manifest_with_multiple_matches)
     with pytest.raises(ValidationError):
         package.get_deployments(w3)

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -1,11 +1,7 @@
 import pytest
 
-from ethpm.exceptions import (
-    InsufficientAssetsError,
-)
-from ethpm.package import (
-    Package,
-)
+from ethpm.exceptions import InsufficientAssetsError
+from ethpm.package import Package
 
 
 @pytest.fixture()
@@ -28,19 +24,19 @@ def test_set_default_web3(all_standalone_manifests, w3):
 
 def test_get_contract_factory_with_unique_web3(safe_math_package, w3):
     contract_factory = safe_math_package.get_contract_factory("SafeMathLib", w3)
-    assert hasattr(contract_factory, 'address')
-    assert hasattr(contract_factory, 'abi')
-    assert hasattr(contract_factory, 'bytecode')
-    assert hasattr(contract_factory, 'bytecode_runtime')
+    assert hasattr(contract_factory, "address")
+    assert hasattr(contract_factory, "abi")
+    assert hasattr(contract_factory, "bytecode")
+    assert hasattr(contract_factory, "bytecode_runtime")
 
 
 def test_get_contract_factory_with_default_web3(safe_math_package, w3):
     safe_math_package.set_default_w3(w3)
     contract_factory = safe_math_package.get_contract_factory("SafeMathLib")
-    assert hasattr(contract_factory, 'address')
-    assert hasattr(contract_factory, 'abi')
-    assert hasattr(contract_factory, 'bytecode')
-    assert hasattr(contract_factory, 'bytecode_runtime')
+    assert hasattr(contract_factory, "address")
+    assert hasattr(contract_factory, "abi")
+    assert hasattr(contract_factory, "bytecode")
+    assert hasattr(contract_factory, "bytecode_runtime")
 
 
 @pytest.mark.parametrize("invalid_w3", ({"invalid": "w3"}))
@@ -56,7 +52,7 @@ def test_get_contract_factory_without_default_web3(safe_math_package):
 
 def test_get_contract_factory_with_missing_contract_types(safe_math_package, w3):
     safe_math_package.set_default_w3(w3)
-    safe_math_package.package_data.pop('contract_types', None)
+    safe_math_package.package_data.pop("contract_types", None)
     with pytest.raises(InsufficientAssetsError):
         assert safe_math_package.get_contract_factory("SafeMathLib")
 

--- a/tests/ethpm/test_package_init_from_file.py
+++ b/tests/ethpm/test_package_init_from_file.py
@@ -4,17 +4,13 @@ import os
 
 import pytest
 
-from ethpm import (
-    Package,
-)
-from ethpm.exceptions import (
-    ValidationError,
-)
+from ethpm import Package
+from ethpm.exceptions import ValidationError
 
 
 @contextlib.contextmanager
 def _generate_fixture_param(tmpdir, as_file_path, file_content):
-    temp_manifest = tmpdir.mkdir('invalid').join('manifest.json')
+    temp_manifest = tmpdir.mkdir("invalid").join("manifest.json")
     temp_manifest.write(file_content)
 
     if as_file_path:
@@ -26,29 +22,33 @@ def _generate_fixture_param(tmpdir, as_file_path, file_content):
 
 @pytest.fixture(params=[True, False])
 def valid_manifest_from_path(tmpdir, request):
-    valid_manifest = json.dumps({
-        "package_name": "foo",
-        "manifest_version": "2",
-        "version": "1.0.0",
-    })
+    valid_manifest = json.dumps(
+        {"package_name": "foo", "manifest_version": "2", "version": "1.0.0"}
+    )
     with _generate_fixture_param(tmpdir, request.param, valid_manifest) as file_obj:
         yield file_obj
 
 
 @pytest.fixture(params=[True, False])
 def invalid_manifest_from_path(tmpdir, request):
-    invalid_manifest = json.dumps({
-        "package_name": "foo",
-        "manifest_version": "not a valid version",
-        "version": "1.0.0",
-    })
-    with _generate_fixture_param(tmpdir, request.param, invalid_manifest) as file_obj_or_path:
+    invalid_manifest = json.dumps(
+        {
+            "package_name": "foo",
+            "manifest_version": "not a valid version",
+            "version": "1.0.0",
+        }
+    )
+    with _generate_fixture_param(
+        tmpdir, request.param, invalid_manifest
+    ) as file_obj_or_path:
         yield file_obj_or_path
 
 
 @pytest.fixture(params=[True, False])
 def non_json_manifest(tmpdir, request):
-    with _generate_fixture_param(tmpdir, request.param, 'This is invalid json') as file_obj_or_path:
+    with _generate_fixture_param(
+        tmpdir, request.param, "This is invalid json"
+    ) as file_obj_or_path:
         yield file_obj_or_path
 
 
@@ -80,10 +80,7 @@ def test_init_from_invalid_argument_type():
 
 
 def test_from_file_fails_with_missing_filepath(tmpdir, w3):
-    path = os.path.join(
-        str(tmpdir.mkdir('invalid')),
-        'manifest.json',
-    )
+    path = os.path.join(str(tmpdir.mkdir("invalid")), "manifest.json")
 
     assert not os.path.exists(path)
     with pytest.raises(FileNotFoundError):

--- a/tests/ethpm/test_package_init_from_ipfs.py
+++ b/tests/ethpm/test_package_init_from_ipfs.py
@@ -1,11 +1,9 @@
 import pytest
 
 import ethpm
-from ethpm import (
-    Package,
-)
+from ethpm import Package
 
-VALID_IPFS_PKG = 'ipfs://QmeD2s7KaBUoGYTP1eutHBmBkMMMoycdfiyGMx2DKrWXyV'
+VALID_IPFS_PKG = "ipfs://QmeD2s7KaBUoGYTP1eutHBmBkMMMoycdfiyGMx2DKrWXyV"
 
 
 # mock out http req to IPFS gateway
@@ -14,25 +12,26 @@ VALID_IPFS_PKG = 'ipfs://QmeD2s7KaBUoGYTP1eutHBmBkMMMoycdfiyGMx2DKrWXyV'
 def mock_request(monkeypatch, safe_math_manifest):
     def mock_fetch(x):
         return safe_math_manifest
-    monkeypatch.setattr(ethpm.package, 'fetch_ipfs_package', mock_fetch)
+
+    monkeypatch.setattr(ethpm.package, "fetch_ipfs_package", mock_fetch)
 
 
 def test_package_from_ipfs_with_valid_uri():
     package = Package.from_ipfs(VALID_IPFS_PKG)
-    assert package.name == 'safe-math-lib'
+    assert package.name == "safe-math-lib"
     assert isinstance(package, Package)
 
 
 @pytest.mark.parametrize(
     "invalid",
     (
-        '123',
-        b'123',
+        "123",
+        b"123",
         {},
-        'ipfs://',
-        'http://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
-        'ipfsQmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
-    )
+        "ipfs://",
+        "http://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
+        "ipfsQmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
+    ),
 )
 def test_package_from_ipfs_rejects_invalid_ipfs_uri(invalid):
     with pytest.raises(TypeError):

--- a/tests/ethpm/test_package_init_from_registry.py
+++ b/tests/ethpm/test_package_init_from_registry.py
@@ -1,16 +1,9 @@
 import pytest
-from solc import (
-    compile_source,
-)
+from solc import compile_source
 
 import ethpm
-from ethpm import (
-    ASSETS_DIR,
-    Package,
-)
-from ethpm.exceptions import (
-    UriNotSupportedError,
-)
+from ethpm import ASSETS_DIR, Package
+from ethpm.exceptions import UriNotSupportedError
 
 
 # mock out http req to IPFS gateway
@@ -19,30 +12,30 @@ from ethpm.exceptions import (
 def mock_request(monkeypatch, owned_manifest):
     def mock_fetch(x):
         return owned_manifest
-    monkeypatch.setattr(ethpm.utils.uri, 'fetch_ipfs_package', mock_fetch)
+
+    monkeypatch.setattr(ethpm.utils.uri, "fetch_ipfs_package", mock_fetch)
 
 
 @pytest.fixture()
 def w3_with_registry(w3):
     # compile registry contract
-    registry_source = ASSETS_DIR / 'Registry.sol'
+    registry_source = ASSETS_DIR / "Registry.sol"
     reg_text = registry_source.read_text()
     compiled_sol = compile_source(reg_text)
-    contract_interface = compiled_sol['<stdin>:Registry']
+    contract_interface = compiled_sol["<stdin>:Registry"]
     # deploy registry contract
-    Registry = w3.eth.contract(abi=contract_interface['abi'], bytecode=contract_interface['bin'])
+    Registry = w3.eth.contract(
+        abi=contract_interface["abi"], bytecode=contract_interface["bin"]
+    )
     tx_hash = Registry.constructor().transact()
     tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
-    address = tx_receipt['contractAddress']
-    registry = w3.eth.contract(
-        address=address,
-        abi=contract_interface['abi'],
-    )
+    address = tx_receipt["contractAddress"]
+    registry = w3.eth.contract(address=address, abi=contract_interface["abi"])
     # register package on deployed registry
     registry.functions.registerPackage(
-        b'owned',  # pkg-name
-        '1.0.0',  # version
-        'ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW'  # content-addressed URI
+        b"owned",  # pkg-name
+        "1.0.0",  # version
+        "ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW",  # content-addressed URI
     ).transact()
     w3.eth.waitForTransactionReceipt(tx_hash)
     return w3, address, registry
@@ -50,19 +43,19 @@ def w3_with_registry(w3):
 
 def test_package_init_from_registry(w3_with_registry):
     w3, address, registry = w3_with_registry
-    valid_registry_uri = 'ercXXX://%s/owned?version=1.0.0' % address
+    valid_registry_uri = "ercXXX://%s/owned?version=1.0.0" % address
     pkg = Package.from_registry(valid_registry_uri, w3)
     assert isinstance(pkg, Package)
-    assert pkg.name == 'owned'
+    assert pkg.name == "owned"
 
 
 @pytest.mark.parametrize(
-    'uri',
+    "uri",
     (
-        'erc111://packages.zeppelin.os/owned',
-        'ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW',
-        'bzz://da6adeeb4589d8652bbe5679aae6b6409ec85a20e92a8823c7c99e25dba9493d'
-    )
+        "erc111://packages.zeppelin.os/owned",
+        "ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW",
+        "bzz://da6adeeb4589d8652bbe5679aae6b6409ec85a20e92a8823c7c99e25dba9493d",
+    ),
 )
 def test_package_init_with_invalid_registry_uri_raises_exception(uri, w3):
     with pytest.raises(UriNotSupportedError):

--- a/tests/ethpm/utils/test_chain_utils.py
+++ b/tests/ethpm/utils/test_chain_utils.py
@@ -1,28 +1,37 @@
 import pytest
 
-from ethpm.utils.chains import (
-    is_BIP122_block_uri,
-    parse_BIP122_uri,
-)
+from ethpm.utils.chains import is_BIP122_block_uri, parse_BIP122_uri
 
-HASH_A = '0x1234567890123456789012345678901234567890123456789012345678901234'
-HASH_A_NO_PREFIX = '1234567890123456789012345678901234567890123456789012345678901234'
-HASH_B = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-HASH_B_NO_PREFIX = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-BLOCK_URI = 'blockchain://{0}/block/{1}'.format(HASH_A_NO_PREFIX, HASH_B_NO_PREFIX)
-TRANSACTION_URI = 'blockchain://{0}/transaction/{1}'.format(HASH_A_NO_PREFIX, HASH_B_NO_PREFIX)
+HASH_A = "0x1234567890123456789012345678901234567890123456789012345678901234"
+HASH_A_NO_PREFIX = "1234567890123456789012345678901234567890123456789012345678901234"
+HASH_B = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+HASH_B_NO_PREFIX = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+BLOCK_URI = "blockchain://{0}/block/{1}".format(HASH_A_NO_PREFIX, HASH_B_NO_PREFIX)
+TRANSACTION_URI = "blockchain://{0}/transaction/{1}".format(
+    HASH_A_NO_PREFIX, HASH_B_NO_PREFIX
+)
 
 
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
         (BLOCK_URI, True),
         (TRANSACTION_URI, False),
-        ('blockchain://{0}/block/{1}'.format(HASH_A, HASH_B_NO_PREFIX), False),
-        ('blockchain://{0}/block/{1}'.format(HASH_A_NO_PREFIX, HASH_B), False),
-        ('blockchain://{0}/block/{1}'.format(HASH_A, HASH_B_NO_PREFIX), False),
-        ('blockchain://{0}/block/{1}'.format(HASH_A_NO_PREFIX[:-1], HASH_B_NO_PREFIX), False),
-        ('blockchain://{0}/block/{1}'.format(HASH_A_NO_PREFIX, HASH_B_NO_PREFIX[:-1]), False),
+        ("blockchain://{0}/block/{1}".format(HASH_A, HASH_B_NO_PREFIX), False),
+        ("blockchain://{0}/block/{1}".format(HASH_A_NO_PREFIX, HASH_B), False),
+        ("blockchain://{0}/block/{1}".format(HASH_A, HASH_B_NO_PREFIX), False),
+        (
+            "blockchain://{0}/block/{1}".format(
+                HASH_A_NO_PREFIX[:-1], HASH_B_NO_PREFIX
+            ),
+            False,
+        ),
+        (
+            "blockchain://{0}/block/{1}".format(
+                HASH_A_NO_PREFIX, HASH_B_NO_PREFIX[:-1]
+            ),
+            False,
+        ),
     ),
 )
 def test_is_BIP122_block_uri(value, expected):
@@ -31,11 +40,8 @@ def test_is_BIP122_block_uri(value, expected):
 
 
 @pytest.mark.parametrize(
-    'value, expected_resource_type',
-    (
-        (TRANSACTION_URI, 'transaction'),
-        (BLOCK_URI, 'block'),
-    ),
+    "value, expected_resource_type",
+    ((TRANSACTION_URI, "transaction"), (BLOCK_URI, "block")),
 )
 def test_parse_BIP122_uri(value, expected_resource_type):
     chain_id, resource_type, resource_identifier = parse_BIP122_uri(value)

--- a/tests/ethpm/utils/test_contract_utils.py
+++ b/tests/ethpm/utils/test_contract_utils.py
@@ -1,9 +1,6 @@
 import pytest
 
-from ethpm.exceptions import (
-    InsufficientAssetsError,
-    ValidationError,
-)
+from ethpm.exceptions import InsufficientAssetsError, ValidationError
 from ethpm.utils.contract import (
     generate_contract_factory_kwargs,
     validate_contract_name,
@@ -15,16 +12,13 @@ from ethpm.utils.contract import (
 @pytest.mark.parametrize(
     "contract_data",
     (
-        {
-            "abi": "",
-            "deployment_bytecode": ""
-        },
+        {"abi": "", "deployment_bytecode": ""},
         {
             "abi": "",
             "deployment_bytecode": {"bytecode": ""},
-            "runtime_bytecode": {"bytecode": ""}
-        }
-    )
+            "runtime_bytecode": {"bytecode": ""},
+        },
+    ),
 )
 def test_validate_minimal_contract_factory_data_validates(contract_data):
     assert validate_minimal_contract_factory_data(contract_data) is None
@@ -36,14 +30,14 @@ def test_validate_minimal_contract_factory_data_validates(contract_data):
         {"abi": ""},
         {"deployment_bytecode": {"bytecode": ""}},
         {"runtime_bytecode": {"bytecode": ""}, "other": ""},
-    )
+    ),
 )
 def test_validate_minimal_contract_factory_data_invalidates(contract_data):
     with pytest.raises(InsufficientAssetsError):
         validate_minimal_contract_factory_data(contract_data)
 
 
-@pytest.mark.parametrize("name", ("A1", "A-1", "A_1", "X"*256))
+@pytest.mark.parametrize("name", ("A1", "A-1", "A_1", "X" * 256))
 def test_validate_contract_name_validates(name):
     assert validate_contract_name(name) is None
 
@@ -60,7 +54,7 @@ def test_validate_contract_name_invalidates(name):
         {"abi": ""},
         {"bytecode": {"bytecode": ""}},
         {"abi": "", "bytecode": {"bytecode": ""}},
-    )
+    ),
 )
 def test_generate_contract_factory_kwargs(contract_data):
     contract_factory = generate_contract_factory_kwargs(contract_data)

--- a/tests/ethpm/utils/test_ipfs_utils.py
+++ b/tests/ethpm/utils/test_ipfs_utils.py
@@ -1,63 +1,60 @@
 import pytest
 
-from ethpm.utils.ipfs import (
-    extract_ipfs_path_from_uri,
-    is_ipfs_uri,
-)
+from ethpm.utils.ipfs import extract_ipfs_path_from_uri, is_ipfs_uri
 
 
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
         (
-            'ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
+            "ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u",
         ),
         (
-            'ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
+            "ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u",
         ),
         (
-            'ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u',
+            "ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u",
         ),
         (
-            'ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
+            "ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
         ),
         (
-            'ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
+            "ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
         ),
         (
-            'ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/',
+            "ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
         ),
         (
-            'ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
+            "ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
         ),
         (
-            'ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
+            "ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
         ),
         (
-            'ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme',
+            "ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme",
         ),
         (
-            'ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
+            "ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
         ),
         (
-            'ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
+            "ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
         ),
         (
-            'ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
-            'QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/',
+            "ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
+            "QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
         ),
-    )
+    ),
 )
 def test_extract_ipfs_path_from_uri(value, expected):
     actual = extract_ipfs_path_from_uri(value)
@@ -65,30 +62,30 @@ def test_extract_ipfs_path_from_uri(value, expected):
 
 
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
-        ('ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u', True),
-        ('ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u', True),
-        ('ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u', True),
-        ('ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/', True),
-        ('ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/', True),
-        ('ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/', True),
-        ('ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme', True),
-        ('ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme', True),
-        ('ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme', True),
-        ('ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', True),
-        ('ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', True),
-        ('ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', True),
+        ("ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u", True),
+        ("ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u", True),
+        ("ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u", True),
+        ("ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/", True),
+        ("ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/", True),
+        ("ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/", True),
+        ("ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme", True),
+        ("ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme", True),
+        ("ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme", True),
+        ("ipfs:QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/", True),
+        ("ipfs:/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/", True),
+        ("ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/", True),
         # malformed
-        ('ipfs//QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', False),
-        ('ipfs/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', False),
-        ('ipfsQmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/', False),
+        ("ipfs//QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/", False),
+        ("ipfs/QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/", False),
+        ("ipfsQmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/", False),
         # HTTP
-        ('http://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme', False),
-        ('https://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme', False),
+        ("http://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme", False),
+        ("https://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme", False),
         # No hash
-        ('ipfs://', False),
-    )
+        ("ipfs://", False),
+    ),
 )
 def test_is_ipfs_uri(value, expected):
     actual = is_ipfs_uri(value)

--- a/tests/ethpm/utils/test_manifest_validation_utils.py
+++ b/tests/ethpm/utils/test_manifest_validation_utils.py
@@ -1,11 +1,7 @@
 import pytest
 
-from ethpm import (
-    V2_PACKAGES_DIR,
-)
-from ethpm.exceptions import (
-    ValidationError,
-)
+from ethpm import V2_PACKAGES_DIR
+from ethpm.exceptions import ValidationError
 from ethpm.utils.manifest_validation import (
     validate_manifest_against_schema,
     validate_manifest_deployments,
@@ -14,7 +10,10 @@ from ethpm.utils.manifest_validation import (
 
 
 def test_validate_manifest_exists_validates():
-    assert validate_manifest_exists(str(V2_PACKAGES_DIR / 'safe-math-lib' / '1.0.0.json')) is None
+    assert (
+        validate_manifest_exists(str(V2_PACKAGES_DIR / "safe-math-lib" / "1.0.0.json"))
+        is None
+    )
 
 
 def test_validate_manifest_exists_invalidates():
@@ -32,7 +31,9 @@ def test_validate_manifest_invalidates(invalid_manifest):
         validate_manifest_against_schema(invalid_manifest)
 
 
-def test_validate_deployed_contracts_present_validates(manifest_with_conflicting_deployments):
+def test_validate_deployed_contracts_present_validates(
+    manifest_with_conflicting_deployments
+):
     with pytest.raises(ValidationError):
         validate_manifest_deployments(manifest_with_conflicting_deployments)
 

--- a/tests/ethpm/utils/test_registry_utils.py
+++ b/tests/ethpm/utils/test_registry_utils.py
@@ -1,69 +1,65 @@
 import pytest
 
-from ethpm.exceptions import (
-    UriNotSupportedError,
-)
-from ethpm.validation import (
-    validate_registry_uri,
-)
+from ethpm.exceptions import UriNotSupportedError
+from ethpm.validation import validate_registry_uri
 
 
 @pytest.mark.parametrize(
-    'uri',
+    "uri",
     (
-        ('ercxxx://zeppelinos.eth/erc20/'),
-        ('ercXXX://zeppelinos.eth/erc20/'),
-        ('ercXXX://zeppelinos.eth/erc20//'),
-        ('ercXXX://zeppelinos.eth/erc20?version=1.0.0'),
-        ('ercXXX://zeppelinos.eth/erc20?version=1.0.0/'),
-        ('ercXXX://packages.zeppelinos.eth/erc20?version='),
-        ('ercXXX://packages.zeppelinos.eth/erc20?version=/'),
-        ('ercXXX://packages.zeppelinos.eth/erc20?version=1.0.0'),
-        ('ercXXX://packages.zeppelinos.eth/erc20?version=1.0.0/'),
-        ('ercXXX://packages.ethereum.eth/greeter?version=%3E%3D1.0.2%2C%3C2'),
-        ('ercXXX://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20?version=1.0.0'),
-        ('ercXXX://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20?version=1.0.0/'),
-    )
+        ("ercxxx://zeppelinos.eth/erc20/"),
+        ("ercXXX://zeppelinos.eth/erc20/"),
+        ("ercXXX://zeppelinos.eth/erc20//"),
+        ("ercXXX://zeppelinos.eth/erc20?version=1.0.0"),
+        ("ercXXX://zeppelinos.eth/erc20?version=1.0.0/"),
+        ("ercXXX://packages.zeppelinos.eth/erc20?version="),
+        ("ercXXX://packages.zeppelinos.eth/erc20?version=/"),
+        ("ercXXX://packages.zeppelinos.eth/erc20?version=1.0.0"),
+        ("ercXXX://packages.zeppelinos.eth/erc20?version=1.0.0/"),
+        ("ercXXX://packages.ethereum.eth/greeter?version=%3E%3D1.0.2%2C%3C2"),
+        ("ercXXX://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20?version=1.0.0"),
+        ("ercXXX://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20?version=1.0.0/"),
+    ),
 )
 def test_is_registry_uri_validates(uri):
     assert validate_registry_uri(uri) is None
 
 
 @pytest.mark.parametrize(
-    'uri',
+    "uri",
     (
         # invalid authority
-        ('ercXXX://packages.zeppelinos.com/erc20?version=1.0.0'),
-        ('ercXXX://package.manager.zeppelinos.eth/erc20?version=1.0.0'),
-        ('ercXXX://packageszeppelinoseth/erc20?version=1.0.0'),
-        ('ercXXX://0xd3cda913deb6f67967b99d67acdfa1712c293601/erc20?version=1.0.0'),
+        ("ercXXX://packages.zeppelinos.com/erc20?version=1.0.0"),
+        ("ercXXX://package.manager.zeppelinos.eth/erc20?version=1.0.0"),
+        ("ercXXX://packageszeppelinoseth/erc20?version=1.0.0"),
+        ("ercXXX://0xd3cda913deb6f67967b99d67acdfa1712c293601/erc20?version=1.0.0"),
         # invalid package name
-        ('ercXXX://packages.zeppelinos.eth/'),
-        ('ercXXX://packages.zeppelinos.eth///'),
-        ('ercXXX://packages.zeppelinos.eth/?version=1.0.0'),
-        ('ercXXX://packages.zeppelinos.eth/!rc20?version=1.0.0'),
+        ("ercXXX://packages.zeppelinos.eth/"),
+        ("ercXXX://packages.zeppelinos.eth///"),
+        ("ercXXX://packages.zeppelinos.eth/?version=1.0.0"),
+        ("ercXXX://packages.zeppelinos.eth/!rc20?version=1.0.0"),
         # invalid version param
-        ('ercXXX://zeppelinos.eth/erc20?versions=1.0.0'),
-        ('ercXXX://zeppelinos.eth/erc20?version1.0.0'),
+        ("ercXXX://zeppelinos.eth/erc20?versions=1.0.0"),
+        ("ercXXX://zeppelinos.eth/erc20?version1.0.0"),
         # malformed
-        ('ercXXXpackageszeppelinosetherc20version1.0.0'),
-        ('ercXXX:packages.zeppelinos.eth/erc20?version=1.0.0'),
-        ('ercXXX:packages.zeppelinos.eth/erc20?version=1.0.0/'),
-        ('ercXXX:/packages.zeppelinos.eth/erc20?version=1.0.0'),
-        ('ercXXX:/packages.zeppelinos.eth/erc20?version=1.0.0/'),
-        ('ercXXX/packages.zeppelinos.eth/erc20?version=1.0.0'),
-        ('ercXXX//packages.zeppelinos.eth/erc20?version=1.0.0'),
-        ('ercXXXpackages.zeppelinos.eth/erc20?version=1.0.0'),
+        ("ercXXXpackageszeppelinosetherc20version1.0.0"),
+        ("ercXXX:packages.zeppelinos.eth/erc20?version=1.0.0"),
+        ("ercXXX:packages.zeppelinos.eth/erc20?version=1.0.0/"),
+        ("ercXXX:/packages.zeppelinos.eth/erc20?version=1.0.0"),
+        ("ercXXX:/packages.zeppelinos.eth/erc20?version=1.0.0/"),
+        ("ercXXX/packages.zeppelinos.eth/erc20?version=1.0.0"),
+        ("ercXXX//packages.zeppelinos.eth/erc20?version=1.0.0"),
+        ("ercXXXpackages.zeppelinos.eth/erc20?version=1.0.0"),
         # wrong scheme
-        ('http://packages.zeppelinos.eth/erc20?version=1.0.0'),
-        ('ercXX://packages.zeppelinos.eth/erc20?version=1.0.0'),
+        ("http://packages.zeppelinos.eth/erc20?version=1.0.0"),
+        ("ercXX://packages.zeppelinos.eth/erc20?version=1.0.0"),
         # no path
-        ('ercXXX://'),
+        ("ercXXX://"),
         # weird values
-        (b'ercXXX://zeppelinos.eth/erc20?version=1.0.0'),
-        ('1234'),
+        (b"ercXXX://zeppelinos.eth/erc20?version=1.0.0"),
+        ("1234"),
         ({}),
-    )
+    ),
 )
 def test_is_registry_uri_raises_exception_for_invalid_uris(uri):
     with pytest.raises(UriNotSupportedError):

--- a/tests/ethpm/utils/test_uri_utils.py
+++ b/tests/ethpm/utils/test_uri_utils.py
@@ -1,42 +1,39 @@
 import pytest
 
-from ethpm.exceptions import (
-    UriNotSupportedError,
-)
-from ethpm.utils.uri import (
-    get_manifest_from_content_addressed_uri,
-)
+from ethpm.exceptions import UriNotSupportedError
+from ethpm.utils.uri import get_manifest_from_content_addressed_uri
 
 
 @pytest.mark.parametrize(
-    'uri,source',
-    (
-        ('ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW', 'ipfs'),
-    )
+    "uri,source", (("ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW", "ipfs"),)
 )
 def test_get_manifest_from_content_addressed_uris_for_supported_schemes(uri, source):
     manifest = get_manifest_from_content_addressed_uri(uri)
-    assert 'version' in manifest
-    assert 'package_name' in manifest
-    assert 'manifest_version' in manifest
+    assert "version" in manifest
+    assert "package_name" in manifest
+    assert "manifest_version" in manifest
 
 
 @pytest.mark.parametrize(
-    'uri',
+    "uri",
     (
         # filesystem
-        ('file:///path_to_erc20.json'),
+        ("file:///path_to_erc20.json"),
         # registry URI scheme
-        ('erc1128://packages.zeppelinos.eth/erc20/v1.0.0'),
+        ("erc1128://packages.zeppelinos.eth/erc20/v1.0.0"),
         # swarm
-        ('bzz://da6adeeb4589d8652bbe5679aae6b6409ec85a20e92a8823c7c99e25dba9493d'),
-        ('bzz-immutable:://da6adeeb4589d8652bbe5679aae6b6409ec85a20e92a8823c7c99e25dba9493d'),
-        ('bzz-raw://da6adeeb4589d8652bbe5679aae6b6409ec85a20e92a8823c7c99e25dba9493d'),
+        ("bzz://da6adeeb4589d8652bbe5679aae6b6409ec85a20e92a8823c7c99e25dba9493d"),
+        (
+            "bzz-immutable:://da6adeeb4589d8652bbe5679aae6b6409ec85a20e92a8823c7c99e25dba9493d"
+        ),
+        ("bzz-raw://da6adeeb4589d8652bbe5679aae6b6409ec85a20e92a8823c7c99e25dba9493d"),
         # internet
-        ('http://github.com/ethpm/ethpm-spec/examples/owned/1.0.0.json#content_hash'),
-        ('https://github.com/ethpm/ethpm-spec/examples/owned/1.0.0.json#content_hash'),
-    )
+        ("http://github.com/ethpm/ethpm-spec/examples/owned/1.0.0.json#content_hash"),
+        ("https://github.com/ethpm/ethpm-spec/examples/owned/1.0.0.json#content_hash"),
+    ),
 )
-def test_get_manfifest_from_content_addressed_uri_raises_exception_for_unsupported_schemes(uri):
+def test_get_manfifest_from_content_addressed_uri_raises_exception_for_unsupported_schemes(
+    uri
+):
     with pytest.raises(UriNotSupportedError):
         get_manifest_from_content_addressed_uri(uri)

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,11 @@ envlist=
 combine_as_imports=True
 force_sort_within_sections=True
 include_trailing_comma=True
-known_third_party=pytest
+known_third_party=pytest,requests_mock
 known_first_party=ethpm
-line_length=21
+line_length=88
 multi_line_output=3
+force_grid_wrap=0
 use_parentheses=True
 
 [flake8]
@@ -36,10 +37,12 @@ basepython =
 whitelist_externals=make
 
 [testenv:lint]
+whitelist_externals=black
 basepython=python
 deps=flake8
 extras=lint
 commands=
 	flake8 {toxinidir}/tests/ethpm {toxinidir}/ethpm 
 	mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p ethpm
-	isort --recursive --check-only --diff {toxinidir}/ethpm/ {toxinidir}/tests/
+	black --check --diff {toxinidir}/ethpm/ --check --diff {toxinidir}/tests/
+	isort --recursive {toxinidir}/ethpm/ {toxinidir}/tests/


### PR DESCRIPTION
### What was wrong?
Standard formatting throughout library would be great, and `black` makes it very easy, though it is very opinionated in the formatting rules it enforces. This pr is what the `py-ethpm` library would look like if we adopted `black`

### How was it fixed?
Add `black` formatting check to tox linting environment

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/42292243-56db0e40-7f8e-11e8-9c76-754d0e59e35c.png)

