### PR TITLE
Change get_contract_type to get_contract_factory

### DIFF
--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -77,7 +77,7 @@ class Package(object):
         """
         self.w3 = w3
 
-    def get_contract_type(self, name: ContractName, w3: Web3=None) -> Contract:
+    def get_contract_factory(self, name: ContractName, w3: Web3=None) -> Contract:
         """
         API to generate a contract factory class.
         """
@@ -185,7 +185,7 @@ class Package(object):
 
         deployments = self.package_data["deployments"][matching_uri]
         all_contract_factories = {
-            deployment_data['contract_type']: self.get_contract_type(
+            deployment_data['contract_type']: self.get_contract_factory(
                 deployment_data['contract_type'],
                 w3
             )

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -26,17 +26,17 @@ def test_set_default_web3(all_standalone_manifests, w3):
         assert current_package.w3 is w3
 
 
-def test_get_contract_type_with_unique_web3(safe_math_package, w3):
-    contract_factory = safe_math_package.get_contract_type("SafeMathLib", w3)
+def test_get_contract_factory_with_unique_web3(safe_math_package, w3):
+    contract_factory = safe_math_package.get_contract_factory("SafeMathLib", w3)
     assert hasattr(contract_factory, 'address')
     assert hasattr(contract_factory, 'abi')
     assert hasattr(contract_factory, 'bytecode')
     assert hasattr(contract_factory, 'bytecode_runtime')
 
 
-def test_get_contract_type_with_default_web3(safe_math_package, w3):
+def test_get_contract_factory_with_default_web3(safe_math_package, w3):
     safe_math_package.set_default_w3(w3)
-    contract_factory = safe_math_package.get_contract_type("SafeMathLib")
+    contract_factory = safe_math_package.get_contract_factory("SafeMathLib")
     assert hasattr(contract_factory, 'address')
     assert hasattr(contract_factory, 'abi')
     assert hasattr(contract_factory, 'bytecode')
@@ -44,26 +44,26 @@ def test_get_contract_type_with_default_web3(safe_math_package, w3):
 
 
 @pytest.mark.parametrize("invalid_w3", ({"invalid": "w3"}))
-def test_get_contract_type_throws_with_invalid_web3(safe_math_package, invalid_w3):
+def test_get_contract_factory_throws_with_invalid_web3(safe_math_package, invalid_w3):
     with pytest.raises(ValueError):
-        safe_math_package.get_contract_type("SafeMathLib", invalid_w3)
+        safe_math_package.get_contract_factory("SafeMathLib", invalid_w3)
 
 
-def test_get_contract_type_without_default_web3(safe_math_package):
+def test_get_contract_factory_without_default_web3(safe_math_package):
     with pytest.raises(ValueError):
-        assert safe_math_package.get_contract_type("SafeMathLib")
+        assert safe_math_package.get_contract_factory("SafeMathLib")
 
 
-def test_get_contract_type_with_missing_contract_types(safe_math_package, w3):
+def test_get_contract_factory_with_missing_contract_types(safe_math_package, w3):
     safe_math_package.set_default_w3(w3)
     safe_math_package.package_data.pop('contract_types', None)
     with pytest.raises(InsufficientAssetsError):
-        assert safe_math_package.get_contract_type("SafeMathLib")
+        assert safe_math_package.get_contract_factory("SafeMathLib")
 
 
-def test_get_contract_type_throws_if_name_isnt_present(safe_math_package, w3):
+def test_get_contract_factory_throws_if_name_isnt_present(safe_math_package, w3):
     with pytest.raises(InsufficientAssetsError):
-        assert safe_math_package.get_contract_type("DoesNotExist", w3)
+        assert safe_math_package.get_contract_factory("DoesNotExist", w3)
 
 
 def test_package_object_properties(safe_math_package):


### PR DESCRIPTION
### What was wrong?
Method `get_contract_type` on `Package` object was confusingly named - updated to `get_contract_factory`



#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/42341955-ff8bf0fe-8051-11e8-96a8-2255137b7d7f.png)

