### PR TITLE
Improve error message when schema invalidates

### DIFF
--- a/ethpm/constants.py
+++ b/ethpm/constants.py
@@ -3,6 +3,6 @@ REGISTRY_URI_SCHEME = "ercxxx"
 
 PACKAGE_NAME_REGEX = "[a-zA-Z][-_a-zA-Z0-9]{0,255}"
 
-IPFS_GATEWAY_PREFIX = "https://gateway.ipfs.io/ipfs/"
+IPFS_GATEWAY_PREFIX = "https://ipfs.io/ipfs/"
 
 INFURA_GATEWAY_PREFIX = "https://ipfs.infura.io/ipfs/"

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -72,8 +72,8 @@ class Package(object):
             validate_minimal_contract_factory_data(contract_data)
         except KeyError:
             raise InsufficientAssetsError(
-                "This package has insufficient package data to generate"
-                "a contract_factory for contract: {0}.".format(name)
+                "This package has insufficient package data to generate "
+                "a contract factory for contract:{0}.".format(name)
             )
 
         contract_kwargs = generate_contract_factory_kwargs(contract_data)

--- a/ethpm/utils/contract.py
+++ b/ethpm/utils/contract.py
@@ -43,8 +43,8 @@ def generate_contract_factory_kwargs(
     """
     if "abi" in contract_data:
         yield "abi", contract_data["abi"]
-    if "bytecode" in contract_data:
-        bytecode = to_bytes(text=contract_data["bytecode"]["bytecode"])
+    if "deployment_bytecode" in contract_data:
+        bytecode = to_bytes(text=contract_data["deployment_bytecode"]["bytecode"])
         yield "bytecode", encode_hex(bytecode)
     if "runtime_bytecode" in contract_data:
         runtime_bytecode = to_bytes(text=contract_data["runtime_bytecode"]["bytecode"])

--- a/ethpm/utils/manifest_validation.py
+++ b/ethpm/utils/manifest_validation.py
@@ -24,9 +24,10 @@ def validate_manifest_against_schema(manifest: Dict[str, Any]) -> None:
     schema_data = _load_schema_data()
     try:
         validate(manifest, schema_data)
-    except jsonValidationError:
+    except jsonValidationError as e:
         raise ValidationError(
-            "Manifest:{0} invalid for schema:{1}".format(manifest, MANIFEST_SCHEMA_PATH)
+            "Manifest invalid for schema version {0}. "
+            "Reason: {1}".format(schema_data["version"], e.message)
         )
 
 

--- a/tests/ethpm/utils/test_contract_utils.py
+++ b/tests/ethpm/utils/test_contract_utils.py
@@ -52,14 +52,19 @@ def test_validate_contract_name_invalidates(name):
     "contract_data",
     (
         {"abi": ""},
-        {"bytecode": {"bytecode": ""}},
-        {"abi": "", "bytecode": {"bytecode": ""}},
+        {"deployment_bytecode": {"bytecode": ""}},
+        {"abi": "", "runtime_bytecode": {"bytecode": ""}},
     ),
 )
 def test_generate_contract_factory_kwargs(contract_data):
     contract_factory = generate_contract_factory_kwargs(contract_data)
     for key in contract_data.keys():
-        assert key in contract_factory
+        if key == "deployment_bytecode":
+            assert "bytecode" in contract_factory
+        elif key == "runtime_bytecode":
+            assert "bytecode_runtime" in contract_factory
+        else:
+            assert key in contract_factory
 
 
 def test_validate_w3_instance_validates(w3):


### PR DESCRIPTION
### What was wrong?
Error message for invalidated manifests was lacking
Also had to update `generate_contract_factory_kwargs` to use the new bytecode object field definition of `deployment_bytecode`

### How was it fixed?
Updated message to include the reason for what went wrong during validation

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/42402131-36137158-8136-11e8-84e9-dc7a24ef9b02.png)

