### PR TITLE
Memoize get backend and update IPFS gateway URI

### DIFF
--- a/ethpm/backends/__init__.py
+++ b/ethpm/backends/__init__.py
@@ -1,3 +1,4 @@
+import functools
 import os
 
 from typing import Type
@@ -9,6 +10,7 @@ from ethpm.utils.module_loading import import_string
 DEFAULT_URI_BACKEND = "ethpm.backends.ipfs.IPFSGatewayBackend"
 
 
+@functools.lru_cache(maxsize=None)
 def get_uri_backend(import_path: str = None) -> BaseURIBackend:
     """
     Return the `BaseURIBackend` class specified by import_path, default, or env variable.

--- a/ethpm/constants.py
+++ b/ethpm/constants.py
@@ -3,6 +3,6 @@ REGISTRY_URI_SCHEME = "ercxxx"
 
 PACKAGE_NAME_REGEX = "[a-zA-Z][-_a-zA-Z0-9]{0,255}"
 
-IPFS_GATEWAY_PREFIX = "https://gateway.ipfs.io/ipfs/"
+IPFS_GATEWAY_PREFIX = "https://ipfs.io/ipfs/"
 
 INFURA_GATEWAY_PREFIX = "https://ipfs.infura.io/ipfs/"

--- a/tests/ethpm/backends/test_get_uri_backend.py
+++ b/tests/ethpm/backends/test_get_uri_backend.py
@@ -1,5 +1,12 @@
+import pytest
+
 from ethpm.backends import get_uri_backend
 from ethpm.backends.ipfs import DummyIPFSBackend, IPFSGatewayBackend
+
+
+@pytest.fixture(autouse=True)
+def reset_get_uri_backend_cache():
+    get_uri_backend.cache_clear()
 
 
 def test_get_uri_backend_default():

--- a/tests/ethpm/test_package_init_from_registry.py
+++ b/tests/ethpm/test_package_init_from_registry.py
@@ -2,7 +2,13 @@ import pytest
 from solc import compile_source
 
 from ethpm import ASSETS_DIR, Package
+from ethpm.backends import get_uri_backend
 from ethpm.exceptions import UriNotSupportedError
+
+
+@pytest.fixture(autouse=True)
+def reset_get_uri_backend_cache():
+    get_uri_backend.cache_clear()
 
 
 @pytest.fixture()


### PR DESCRIPTION
### What was wrong?

We are instantiating URI backends every time URIs are requested.  This doesn't seem quite right.  Also, the IPFS gateway URL was outdated.

### How was it fixed?

Added `lru_cache` decorator to `get_uri_backend` function.  Also updated IPFS gateway URL.

#### Cute Animal Picture

![Cute animal picture](http://2.bp.blogspot.com/-t4qLJule-DQ/UOGoODQNfWI/AAAAAAAADL8/TcNHOkIMXfg/s1600/animals_couple_10.jpg)
