### PR TITLE
Remove unnecessary encoding

### DIFF
--- a/ethpm/utils/contract.py
+++ b/ethpm/utils/contract.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any, Dict, Generator, List, Tuple
 
-from eth_utils import encode_hex, to_bytes, to_dict
+from eth_utils import to_dict
 from solc import compile_files
 from web3 import Web3
 
@@ -44,11 +44,9 @@ def generate_contract_factory_kwargs(
     if "abi" in contract_data:
         yield "abi", contract_data["abi"]
     if "deployment_bytecode" in contract_data:
-        bytecode = to_bytes(text=contract_data["deployment_bytecode"]["bytecode"])
-        yield "bytecode", encode_hex(bytecode)
+        yield "bytecode", contract_data["deployment_bytecode"]["bytecode"]
     if "runtime_bytecode" in contract_data:
-        runtime_bytecode = to_bytes(text=contract_data["runtime_bytecode"]["bytecode"])
-        yield "bytecode_runtime", encode_hex(runtime_bytecode)
+        yield "bytecode_runtime", contract_data["runtime_bytecode"]["bytecode"]
 
 
 def compile_contracts(contract_name: str, alias: str, paths: List[str]) -> str:


### PR DESCRIPTION
### What was wrong?
Unnecessary encoding was screwing up integration with web3. When trying to deploy a contract factory - web3 was throwing up the error 
```python
evm.exceptions.OutOfGas: Out of gas: Needed 14669191620976456158278888118536457640064080807820771150891628021831785358189269564264174191 - Remaining 2761367 - Reason: Expanding memory 0 -> 2773243793210128911170624863737230394398208717504
```

### How was it fixed?
Removed unnecessary encoding

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/42473289-72afdef6-8381-11e8-8a71-06c46b92f414.png)
