### PR TITLE
Implement `Package.get_contract_instance`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'bumpversion>=0.5.3,<1',
         'eth-keys>=0.2.0b3,<1',
         'eth-tester[py-evm]==0.1.0-beta.26',
+        'eth-typing>=1.0.0,<2',
         'eth-utils>=1.0.2,<2',
         'ipfsapi>=0.4.3,<1',
         'jsonschema>=2.6.0,<3',

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -1,3 +1,4 @@
+from eth_utils import is_same_address
 import pytest
 
 from ethpm.exceptions import InsufficientAssetsError
@@ -7,6 +8,15 @@ from ethpm.package import Package
 @pytest.fixture()
 def safe_math_package(safe_math_manifest):
     return Package(safe_math_manifest)
+
+
+@pytest.fixture()
+def deployed_safe_math(safe_math_package, w3):
+    safe_math_package.set_default_w3(w3)
+    SafeMath = safe_math_package.get_contract_factory("SafeMathLib")
+    tx_hash = SafeMath.constructor().transact()
+    tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    return safe_math_package, tx_receipt.contractAddress
 
 
 def test_package_object_instantiates_with_a_web3_object(all_standalone_manifests, w3):
@@ -60,6 +70,22 @@ def test_get_contract_factory_with_missing_contract_types(safe_math_package, w3)
 def test_get_contract_factory_throws_if_name_isnt_present(safe_math_package, w3):
     with pytest.raises(InsufficientAssetsError):
         assert safe_math_package.get_contract_factory("DoesNotExist", w3)
+
+
+def test_get_contract_instance(deployed_safe_math):
+    safe_math_package, address = deployed_safe_math
+    contract_instance = safe_math_package.get_contract_instance("SafeMathLib", address)
+    assert contract_instance.abi is not False
+    assert is_same_address(contract_instance.address, address)
+
+
+def test_get_contract_instance_throws_with_insufficient_assets(deployed_safe_math):
+    safe_math_package, address = deployed_safe_math
+    with pytest.raises(InsufficientAssetsError):
+        assert safe_math_package.get_contract_instance("IncorrectLib", address)
+    safe_math_package.package_data["contract_types"]["SafeMathLib"].pop("abi")
+    with pytest.raises(InsufficientAssetsError):
+        assert safe_math_package.get_contract_instance("SafeMathLib", address)
 
 
 def test_package_object_properties(safe_math_package):


### PR DESCRIPTION
### What was wrong?
Since we have `Package.get_contract_factory` it seemed useful to implement `Package.get_contract_instance`. So you can easily fetch an instance of a contract at an address (though the `package_data` MUST contain the abi for this contract in its `contract_types`).
ie. with
```python
token_package = web3.pm.get_package_from_manifest(standard_token_manifest)
ERC20 = token_package.get_contract_factory('StandardToken')
tx_hash = ERC20.constructor(100).transact()
tx_receipt = web3.eth.getTransactionReceipt(tx_hash)
address = tx_receipt["contractAddress"]
```
you can directly get the contract instance from the package
```python
erc20 = token_package.get_contract_instance('StandardToken', address)
total_supply = erc20.functions.totalSupply().call()
```
rather than using web3
```python
erc20 = web3.eth.contract(address=address, abi=ERC20.abi)
total_supply = erc20.functions.totalSupply().call()
```

### How was it fixed?
Wrote `Package.get_contract_instance` that uses similar validation to `get_contract_factory`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/42479385-e5e616c4-8395-11e8-8454-6869c7f7ab6a.png)
