### PR TITLE
Support Packages with build dependencies

### DIFF
--- a/ethpm/backends/ipfs.py
+++ b/ethpm/backends/ipfs.py
@@ -68,6 +68,13 @@ class InfuraIPFSBackend(IPFSOverHTTPBackend):
         return INFURA_GATEWAY_PREFIX
 
 
+MANIFEST_URIS = {
+    "ipfs://QmVu9zuza5mkJwwcFdh2SXBugm1oSgZVuEKkph9XLsbUwg": "standard-token",
+    "ipfs://QmeD2s7KaBUoGYTP1eutHBmBkMMMoycdfiyGMx2DKrWXyV": "safe-math-lib",
+    "ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW": "owned",
+}
+
+
 class DummyIPFSBackend(BaseIPFSBackend):
     """
     Backend class to serve IPFS URIs without having to make an HTTP request.
@@ -79,21 +86,13 @@ class DummyIPFSBackend(BaseIPFSBackend):
     """
 
     def fetch_uri_contents(self, ipfs_uri: str) -> bytes:
-        if is_ipfs_uri(ipfs_uri):
-            with open(
-                str(V2_PACKAGES_DIR / "safe-math-lib" / "1.0.0.json")
-            ) as file_obj:
-                contents = file_obj.read()
-        else:
-            with open(str(V2_PACKAGES_DIR / ipfs_uri)) as file_obj:
-                contents = file_obj.read()
+        pkg_name = MANIFEST_URIS[ipfs_uri]
+        with open(str(V2_PACKAGES_DIR / pkg_name / "1.0.0.json")) as file_obj:
+            contents = file_obj.read()
         return to_bytes(text=contents)
 
     def can_handle_uri(self, uri: str) -> bool:
-        if is_ipfs_uri(uri):
-            return True
-        path = V2_PACKAGES_DIR / uri
-        return path.exists()
+        return uri in MANIFEST_URIS
 
 
 class LocalIPFSBackend(BaseIPFSBackend):

--- a/ethpm/dependencies.py
+++ b/ethpm/dependencies.py
@@ -1,0 +1,41 @@
+from typing import Dict, List
+
+
+class Dependencies:
+    """
+    Access build dependencies belonging to a package.
+    """
+
+    def __init__(self, build_dependencies: Dict[str, "Package"]) -> None:
+        self.build_dependencies = build_dependencies
+
+    def __getitem__(self, key: str) -> "Package":
+        return self.get(key)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.build_dependencies
+
+    def _validate_name(self, name: str) -> None:
+        if name not in self.build_dependencies:
+            raise KeyError(
+                "Package name: {0} not found in build dependencies.".format(name)
+            )
+
+    def get(self, key: str) -> "Package":
+        self._validate_name(key)
+        return self.build_dependencies.get(key)
+
+    def items(self) -> Dict[str, "Package"]:
+        item_dict = {name: self.get(name) for name in self.build_dependencies}
+        return item_dict
+
+    def values(self) -> List["Package"]:
+        values = [self.get(name) for name in self.build_dependencies]
+        return values
+
+    def get_dependency_package(self, package_name: str) -> "Package":
+        """
+        Return a the dependency Package of the given package name.
+        """
+        self._validate_name(package_name)
+        return self.get(package_name)

--- a/ethpm/exceptions.py
+++ b/ethpm/exceptions.py
@@ -25,7 +25,15 @@ class ValidationError(PyEthPMError):
 
 class UriNotSupportedError(ValidationError):
     """
-    Raised when URI scheme does not conform to the registry URI scheme.
+    Raised when URI scheme is invalid or not supported by the current backend.
+    """
+
+    pass
+
+
+class FailureToFetchIPFSAssetsError(PyEthPMError):
+    """
+    Raised when an attempt to fetch a Package's assets via IPFS failed.
     """
 
     pass

--- a/ethpm/utils/manifest_validation.py
+++ b/ethpm/utils/manifest_validation.py
@@ -39,6 +39,14 @@ def validate_deployments_are_present(manifest: Dict[str, Any]) -> None:
         raise ValidationError("Manifest's deployments key is empty.")
 
 
+def validate_build_dependencies_are_present(manifest: Dict[str, Any]) -> None:
+    if "build_dependencies" not in manifest:
+        raise ValidationError("Manifest doesn't have any build dependencies.")
+
+    if not manifest["build_dependencies"]:
+        raise ValidationError("Manifest's build dependencies key is empty.")
+
+
 def validate_manifest_deployments(manifest: Dict[str, Any]) -> None:
     """
     Validate that a manifest's deployments contracts reference existing contract_types.
@@ -59,16 +67,6 @@ def validate_manifest_deployments(manifest: Dict[str, Any]) -> None:
                     missing_contract_types
                 )
             )
-
-
-def check_for_build_dependencies(valid_manifest: Dict[str, Any]) -> None:
-    """
-    Catch packages that rely on other packages
-    """
-    if valid_manifest.get("build_dependencies"):
-        raise NotImplementedError(
-            "Handling of build dependencies has not yet been implemented"
-        )
 
 
 def validate_manifest_exists(manifest_id: str) -> None:

--- a/ethpm/validation.py
+++ b/ethpm/validation.py
@@ -1,10 +1,12 @@
 import re
+from typing import Dict
 from urllib import parse
 
 from eth_utils import is_checksum_address
 
 from ethpm.constants import PACKAGE_NAME_REGEX, REGISTRY_URI_SCHEME
 from ethpm.exceptions import UriNotSupportedError
+from ethpm.utils.ipfs import is_ipfs_uri
 from ethpm.utils.registry import is_ens_domain
 
 
@@ -15,6 +17,16 @@ def validate_package_name(pkg_name: str) -> None:
     """
     if not bool(re.match(PACKAGE_NAME_REGEX, pkg_name)):
         raise UriNotSupportedError("{0} is not a valid package name.".format(pkg_name))
+
+
+def validate_build_dependencies(dependencies: Dict[str, str]) -> None:
+    """
+    Raise an exception if the key in dependencies is not a valid package name,
+    or if the value is not a valid IPFS URI.
+    """
+    for key, value in dependencies.items():
+        validate_package_name(key)
+        is_ipfs_uri(value)
 
 
 def validate_registry_uri(uri: str) -> None:

--- a/ethpm/validation.py
+++ b/ethpm/validation.py
@@ -1,11 +1,10 @@
 import re
-from typing import Dict
 from urllib import parse
 
 from eth_utils import is_checksum_address
 
 from ethpm.constants import PACKAGE_NAME_REGEX, REGISTRY_URI_SCHEME
-from ethpm.exceptions import UriNotSupportedError
+from ethpm.exceptions import UriNotSupportedError, ValidationError
 from ethpm.utils.ipfs import is_ipfs_uri
 from ethpm.utils.registry import is_ens_domain
 
@@ -19,14 +18,21 @@ def validate_package_name(pkg_name: str) -> None:
         raise UriNotSupportedError("{0} is not a valid package name.".format(pkg_name))
 
 
-def validate_build_dependencies(dependencies: Dict[str, str]) -> None:
+def validate_ipfs_uri(uri: str) -> None:
+    """
+    Raise an exception if the provided URI is not a valid IPFS URI.
+    """
+    if not is_ipfs_uri(uri):
+        raise ValidationError("URI: {0} is not a valid IPFS URI.".format(uri))
+
+
+def validate_build_dependency(key: str, uri: str) -> None:
     """
     Raise an exception if the key in dependencies is not a valid package name,
     or if the value is not a valid IPFS URI.
     """
-    for key, value in dependencies.items():
-        validate_package_name(key)
-        is_ipfs_uri(value)
+    validate_package_name(key)
+    validate_ipfs_uri(uri)
 
 
 def validate_registry_uri(uri: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,14 +19,13 @@ PACKAGE_NAMES = [
     "wallet",
 ]
 
+
 def fetch_manifest(name):
-    with open(str(V2_PACKAGES_DIR / name / '1.0.0.json')) as file_obj:
+    with open(str(V2_PACKAGES_DIR / name / "1.0.0.json")) as file_obj:
         return json.load(file_obj)
 
 
-MANIFESTS = {
-    name: fetch_manifest(name) for name in PACKAGE_NAMES
-}
+MANIFESTS = {name: fetch_manifest(name) for name in PACKAGE_NAMES}
 
 
 @pytest.fixture
@@ -37,9 +36,17 @@ def w3():
 
 
 @pytest.fixture
+def dummy_ipfs_backend(monkeypatch):
+    monkeypatch.setenv(
+        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
+    )
+
+
+@pytest.fixture
 def get_manifest():
     def _get_manifest(name):
         return copy.deepcopy(MANIFESTS[name])
+
     return _get_manifest
 
 
@@ -53,7 +60,7 @@ def all_manifests(get_manifest):
 # should be extended to all_manifest_types asap
 @pytest.fixture
 def safe_math_manifest(get_manifest):
-    return get_manifest('safe-math-lib')
+    return get_manifest("safe-math-lib")
 
 
 @pytest.fixture
@@ -64,8 +71,7 @@ def piper_coin_manifest():
 
 @pytest.fixture
 def standard_token_manifest():
-    with open(str(V2_PACKAGES_DIR / "standard-token" / "1.0.0.json")) as file_obj:
-        return json.load(file_obj)
+    return get_manifest("standard-token")
 
 
 # standalone = no `build_dependencies` which aren't fully supported yet

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,18 @@ def safe_math_manifest(get_manifest):
     return get_manifest('safe-math-lib')
 
 
+@pytest.fixture
+def piper_coin_manifest():
+    with open(str(V2_PACKAGES_DIR / "piper-coin" / "1.0.0-pretty.json")) as file_obj:
+        return json.load(file_obj)
+
+
+@pytest.fixture
+def standard_token_manifest():
+    with open(str(V2_PACKAGES_DIR / "standard-token" / "1.0.0.json")) as file_obj:
+        return json.load(file_obj)
+
+
 # standalone = no `build_dependencies` which aren't fully supported yet
 @pytest.fixture
 def all_standalone_manifests(all_manifests):

--- a/tests/ethpm/backends/test_ipfs_backends.py
+++ b/tests/ethpm/backends/test_ipfs_backends.py
@@ -71,7 +71,9 @@ def test_base_ipfs_gateway_backend_correctly_handle_uri_schemes(uri, expected):
 
 
 def test_dummy_ipfs_backend():
-    pkg = DummyIPFSBackend().fetch_uri_contents("safe-math-lib/1.0.0.json")
+    pkg = DummyIPFSBackend().fetch_uri_contents(
+        "ipfs://QmeD2s7KaBUoGYTP1eutHBmBkMMMoycdfiyGMx2DKrWXyV"
+    )
     mnfst = to_text(pkg)
     manifest = json.loads(mnfst)
     assert manifest["package_name"] == "safe-math-lib"
@@ -82,9 +84,9 @@ def test_get_ipfs_backend_default():
     assert isinstance(backend, IPFSGatewayBackend)
 
 
-def test_get_uri_backend_with_env_variable(monkeypatch):
+def test_get_uri_backend_with_env_variable(dummy_ipfs_backend, monkeypatch):
     monkeypatch.setenv(
-        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
+        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.LocalIPFSBackend"
     )
     backend = get_ipfs_backend()
-    assert isinstance(backend, DummyIPFSBackend)
+    assert isinstance(backend, LocalIPFSBackend)

--- a/tests/ethpm/test_dependencies.py
+++ b/tests/ethpm/test_dependencies.py
@@ -1,0 +1,65 @@
+import pytest
+
+from ethpm import Package
+from ethpm.dependencies import Dependencies
+from ethpm.exceptions import UriNotSupportedError
+from ethpm.validation import validate_build_dependencies
+
+
+@pytest.fixture
+def dependencies(monkeypatch, standard_token_manifest, piper_coin_manifest):
+    monkeypatch.setenv(
+        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
+    )
+    deps = piper_coin_manifest["build_dependencies"]
+    dep_pkgs = {dep: Package.from_ipfs(uri) for dep, uri in deps.items()}
+    return Dependencies(dep_pkgs)
+
+
+@pytest.fixture
+def safe_math_lib_package(safe_math_manifest):
+    return Package(safe_math_manifest)
+
+
+@pytest.fixture
+def invalid_manifest(piper_coin_manifest):
+    piper_coin_manifest["build_dependencies"]["_invalid_package_name"] = []
+    return piper_coin_manifest
+
+
+def test_dependencies_implements_getitem(dependencies, safe_math_lib_package):
+    assert isinstance(dependencies, Dependencies)
+    # difference in name is a result of using the DummyIPFSBackend class
+    # TODO: update backend to return custom ipfs uris
+    assert dependencies["standard-token"].name == "safe-math-lib"
+
+
+def test_dependencies_items(dependencies):
+    result = dependencies.items()
+    assert "standard-token" in result
+    assert isinstance(result["standard-token"], Package)
+
+
+def test_dependencies_values(dependencies):
+    result = dependencies.values()
+    assert len(result) is 1
+    assert isinstance(result[0], Package)
+
+
+def test_get_dependency_package(dependencies):
+    result = dependencies.get_dependency_package("standard-token")
+    assert isinstance(result, Package)
+    assert result.name == "safe-math-lib"
+
+
+def test_validate_build_dependencies(monkeypatch, piper_coin_manifest):
+    monkeypatch.setenv(
+        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
+    )
+    result = validate_build_dependencies(piper_coin_manifest["build_dependencies"])
+    assert result is None
+
+
+def test_get_build_dependencies_invalidates(invalid_manifest):
+    with pytest.raises(UriNotSupportedError):
+        validate_build_dependencies(invalid_manifest["build_dependencies"])

--- a/tests/ethpm/test_get_build_dependencies.py
+++ b/tests/ethpm/test_get_build_dependencies.py
@@ -1,0 +1,35 @@
+import pytest
+
+from ethpm import Package
+from ethpm.dependencies import Dependencies
+from ethpm.exceptions import ValidationError
+
+
+def test_get_build_dependencies(monkeypatch, piper_coin_manifest, w3):
+    monkeypatch.setenv(
+        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
+    )
+    pkg = Package(piper_coin_manifest, w3)
+    build_deps = pkg.get_build_dependencies()
+    assert isinstance(build_deps, Dependencies)
+
+
+def test_get_build_dependencies_without_dependencies_raises_exception(
+    piper_coin_manifest
+):
+    piper_coin_manifest.pop("build_dependencies", None)
+    pkg = Package(piper_coin_manifest)
+    with pytest.raises(ValidationError):
+        pkg.get_build_dependencies()
+
+
+def test_get_build_dependencies_with_empty_dependencies_raises_exception(
+    monkeypatch, piper_coin_manifest
+):
+    monkeypatch.setenv(
+        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
+    )
+    piper_coin_manifest["build_dependencies"] = {}
+    pkg = Package(piper_coin_manifest)
+    with pytest.raises(ValidationError):
+        pkg.get_build_dependencies()

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -6,7 +6,7 @@ from ethpm.package import Package
 
 @pytest.fixture()
 def safe_math_package(get_manifest):
-    safe_math_manifest = get_manifest('safe-math-lib')
+    safe_math_manifest = get_manifest("safe-math-lib")
     return Package(safe_math_manifest)
 
 

--- a/tests/ethpm/test_package_init_from_file.py
+++ b/tests/ethpm/test_package_init_from_file.py
@@ -69,6 +69,16 @@ def test_package_init_for_all_manifest_use_cases(all_standalone_manifests):
         Package(manifest)
 
 
+def test_package_init_for_manifest_with_build_dependency(
+    monkeypatch, piper_coin_manifest, w3
+):
+    monkeypatch.setenv(
+        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
+    )
+    pkg = Package(piper_coin_manifest, w3)
+    assert isinstance(pkg, Package)
+
+
 def test_init_from_invalid_manifest_data():
     with pytest.raises(ValidationError):
         Package({})

--- a/tests/ethpm/test_package_init_from_file.py
+++ b/tests/ethpm/test_package_init_from_file.py
@@ -70,11 +70,8 @@ def test_package_init_for_all_manifest_use_cases(all_standalone_manifests):
 
 
 def test_package_init_for_manifest_with_build_dependency(
-    monkeypatch, piper_coin_manifest, w3
+    dummy_ipfs_backend, piper_coin_manifest, w3
 ):
-    monkeypatch.setenv(
-        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
-    )
     pkg = Package(piper_coin_manifest, w3)
     assert isinstance(pkg, Package)
 

--- a/tests/ethpm/test_package_init_from_ipfs.py
+++ b/tests/ethpm/test_package_init_from_ipfs.py
@@ -1,14 +1,12 @@
 import pytest
 
 from ethpm import Package
+from ethpm.exceptions import UriNotSupportedError
 
 VALID_IPFS_PKG = "ipfs://QmeD2s7KaBUoGYTP1eutHBmBkMMMoycdfiyGMx2DKrWXyV"
 
 
-def test_package_from_ipfs_with_valid_uri(monkeypatch):
-    monkeypatch.setenv(
-        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
-    )
+def test_package_from_ipfs_with_valid_uri(dummy_ipfs_backend):
     package = Package.from_ipfs(VALID_IPFS_PKG)
     assert package.name == "safe-math-lib"
     assert isinstance(package, Package)
@@ -26,5 +24,5 @@ def test_package_from_ipfs_with_valid_uri(monkeypatch):
     ),
 )
 def test_package_from_ipfs_rejects_invalid_ipfs_uri(invalid):
-    with pytest.raises(TypeError):
+    with pytest.raises(UriNotSupportedError):
         Package.from_ipfs(invalid)

--- a/tests/ethpm/test_package_init_from_registry.py
+++ b/tests/ethpm/test_package_init_from_registry.py
@@ -30,15 +30,12 @@ def w3_with_registry(w3):
     return w3, address, registry
 
 
-def test_package_init_from_registry(w3_with_registry, monkeypatch):
-    monkeypatch.setenv(
-        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
-    )
+def test_package_init_from_registry(w3_with_registry, dummy_ipfs_backend):
     w3, address, registry = w3_with_registry
     valid_registry_uri = "ercXXX://%s/owned?version=1.0.0" % address
     pkg = Package.from_registry(valid_registry_uri, w3)
     assert isinstance(pkg, Package)
-    assert pkg.name == "safe-math-lib"
+    assert pkg.name == "owned"
 
 
 @pytest.mark.parametrize(

--- a/tests/ethpm/utils/test_uri_utils.py
+++ b/tests/ethpm/utils/test_uri_utils.py
@@ -8,11 +8,8 @@ from ethpm.utils.uri import get_manifest_from_content_addressed_uri
     "uri,source", (("ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW", "ipfs"),)
 )
 def test_get_manifest_from_content_addressed_uris_for_supported_schemes(
-    uri, source, monkeypatch
+    uri, source, dummy_ipfs_backend
 ):
-    monkeypatch.setenv(
-        "ETHPM_URI_BACKEND_CLASS", "ethpm.backends.ipfs.DummyIPFSBackend"
-    )
     manifest = get_manifest_from_content_addressed_uri(uri)
     assert "version" in manifest
     assert "package_name" in manifest


### PR DESCRIPTION
### What was wrong?
We want to be able to support packages with build dependencies.

### How was it fixed?
Wrote a `Dependencies` class that stores (`pkg_name` => `Package`) of the `"build_dependencies"` in a `Package`s manifest. Also performs validation to make sure `pkg_name` is a valid package name and the uri it's pointing to in the manifest is a valid IPFS uri (i.e. `ipfs://Qme2.....`)


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/42670966-07f7f570-861b-11e8-8404-19aabe847b92.png)
