### PR TITLE
Implement Deployments.get_contract_instance

### DIFF
--- a/ethpm/deployments.py
+++ b/ethpm/deployments.py
@@ -1,5 +1,6 @@
 from typing import Dict, ItemsView, List
 
+from eth_utils import to_bytes
 from web3.eth import Contract
 from web3.main import Web3
 
@@ -48,8 +49,13 @@ class Deployments:
         """
         self._validate_name_and_references(contract_name)
         factory = self.contract_factories[contract_name]
-        address = self.deployment_data[contract_name]["address"]
-        return self.w3.eth.contract(address=address, abi=factory.abi)
+        address = to_bytes(hexstr=self.deployment_data[contract_name]["address"])
+        contract_kwargs = {
+            "abi": factory.abi,
+            "bytecode": factory.bytecode,
+            "bytecode_runtime": factory.bytecode_runtime,
+        }
+        return self.w3.eth.contract(address=address, **contract_kwargs)
 
     def _validate_name_and_references(self, name: str) -> None:
         validate_contract_name(name)

--- a/ethpm/deployments.py
+++ b/ethpm/deployments.py
@@ -47,9 +47,9 @@ class Deployments:
         after validating contract name.
         """
         self._validate_name_and_references(contract_name)
-        raise NotImplementedError(
-            "All checks passed, but get_contract_instance API not complete."
-        )
+        factory = self.contract_factories[contract_name]
+        address = self.deployment_data[contract_name]["address"]
+        return self.w3.eth.contract(address=address, abi=factory.abi)
 
     def _validate_name_and_references(self, name: str) -> None:
         validate_contract_name(name)

--- a/ethpm/utils/deployment_validation.py
+++ b/ethpm/utils/deployment_validation.py
@@ -7,7 +7,10 @@ from ethpm.utils.chains import check_if_chain_matches_chain_uri
 
 
 def validate_single_matching_uri(all_blockchain_uris: List[str], w3: Web3) -> str:
-
+    """
+    Return a single block URI after validating that it is the *only* URI in
+    all_blockchain_uris that matches the w3 instance.
+    """
     matching_uris = [
         uri for uri in all_blockchain_uris if check_if_chain_matches_chain_uri(w3, uri)
     ]

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         'jsonschema>=2.6.0,<3',
         'py-solc>=2.1.0,<3',
         'rlp>=1.0.1,<2',
-        'web3>=4.2.1,<5',
+        'web3>=4.5.0,<5',
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.5, <4',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import copy
 import json
 
+from eth_utils import to_hex
 import pytest
 from web3 import Web3
 
@@ -96,6 +97,15 @@ def manifest_with_empty_deployments(tmpdir, safe_math_manifest):
 def manifest_with_matching_deployment(w3, tmpdir, safe_math_manifest):
     w3.testing.mine(5)
     chain_id = get_chain_id(w3)
+    safe_math_bin = safe_math_manifest["contract_types"]["SafeMathLib"][
+        "deployment_bytecode"
+    ]["bytecode"]
+    safe_math_abi = safe_math_manifest["contract_types"]["SafeMathLib"]["abi"]
+    # deploy safe-math-lib
+    SML = w3.eth.contract(abi=safe_math_abi, bytecode=safe_math_bin)
+    tx_hash = SML.constructor().transact()
+    tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    address = tx_receipt.contractAddress
     block = w3.eth.getBlock("earliest")
     block_uri = create_block_uri(w3.toHex(chain_id), w3.toHex(block.hash))
     manifest = copy.deepcopy(safe_math_manifest)
@@ -103,17 +113,18 @@ def manifest_with_matching_deployment(w3, tmpdir, safe_math_manifest):
     manifest["deployments"][block_uri] = {
         "SafeMathLib": {
             "contract_type": "SafeMathLib",
-            "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
-            "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
-            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c",
+            "address": address,
+            "transaction": to_hex(tx_receipt.transactionHash),
+            "block": to_hex(tx_receipt.blockHash),
         }
     }
-    return manifest
+    return manifest, address
 
 
 @pytest.fixture
 def matching_package(manifest_with_matching_deployment):
-    return Package(manifest_with_matching_deployment)
+    manifest, _ = manifest_with_matching_deployment
+    return Package(manifest)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import json
 import pytest
 from web3 import Web3
 
-from ethpm import V2_PACKAGES_DIR
+from ethpm import V2_PACKAGES_DIR, Package
 from ethpm.utils.chains import create_block_uri, get_chain_id
 
 PACKAGE_NAMES = [
@@ -109,6 +109,11 @@ def manifest_with_matching_deployment(w3, tmpdir, safe_math_manifest):
         }
     }
     return manifest
+
+
+@pytest.fixture
+def matching_package(manifest_with_matching_deployment):
+    return Package(manifest_with_matching_deployment)
 
 
 @pytest.fixture

--- a/tests/ethpm/test_get_deployments.py
+++ b/tests/ethpm/test_get_deployments.py
@@ -7,7 +7,8 @@ from ethpm.exceptions import ValidationError
 
 @pytest.fixture
 def matching_package(manifest_with_matching_deployment, w3):
-    return Package(manifest_with_matching_deployment, w3)
+    manifest, _ = manifest_with_matching_deployment
+    return Package(manifest, w3)
 
 
 def test_get_deployments_with_empty_deployment_raise_exception(

--- a/tests/ethpm/utils/test_manifest_validation_utils.py
+++ b/tests/ethpm/utils/test_manifest_validation_utils.py
@@ -39,7 +39,8 @@ def test_validate_deployed_contracts_present_validates(
 
 
 def test_validate_deployments(manifest_with_matching_deployment):
-    validate = validate_manifest_deployments(manifest_with_matching_deployment)
+    manifest, _ = manifest_with_matching_deployment
+    validate = validate_manifest_deployments(manifest)
     assert validate is None
 
 


### PR DESCRIPTION
### What was wrong?
`get_contract_instance` for a deployed contract in a `Deployments` object wasn't implemented


### How was it fixed?
Wrote `Deployments.get_contract_instance(contract_name)` that:
- validates `contract_name`
- creates and returns a contract instance of `contract_name` if deployments data is valid with the current w3 object belonging to `Deployments`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/42713750-c4caba42-86ad-11e8-863e-cfb7c8bbf988.png)

