### PR TITLE
Require w3 instance upon package instantiation

### DIFF
--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -36,12 +36,11 @@ from ethpm.validation import validate_build_dependency, validate_registry_uri
 
 
 class Package(object):
-    def __init__(self, manifest: Dict[str, Any], w3: Web3 = None) -> None:
+    def __init__(self, manifest: Dict[str, Any], w3: Web3) -> None:
         """
-        A package must be constructed with a valid manifest.
+        A package must be constructed with a dict representing a valid manifest
+        and a valid w3 instance.
         """
-        self.w3 = w3
-
         if not isinstance(manifest, dict):
             raise TypeError(
                 "Package object must be initialized with a dictionary. "
@@ -50,73 +49,30 @@ class Package(object):
 
         validate_manifest_against_schema(manifest)
         validate_manifest_deployments(manifest)
+        validate_w3_instance(w3)
 
         self.package_data = manifest
+        self.w3 = w3
 
     def set_default_w3(self, w3: Web3) -> None:
         """
         Set the default Web3 instance.
         """
+        validate_w3_instance(w3)
         self.w3 = w3
-
-    def get_contract_factory(self, name: ContractName, w3: Web3 = None) -> Contract:
-        """
-        API to generate a contract factory class.
-        """
-        validate_contract_name(name)
-        current_w3 = self.get_w3_instance(w3)
-
-        try:
-            contract_data = self.package_data["contract_types"][name]
-            validate_minimal_contract_factory_data(contract_data)
-        except KeyError:
-            raise InsufficientAssetsError(
-                "This package has insufficient package data to generate "
-                "a contract factory for contract:{0}.".format(name)
-            )
-
-        contract_kwargs = generate_contract_factory_kwargs(contract_data)
-        contract_factory = current_w3.eth.contract(**contract_kwargs)
-        return contract_factory
-
-    def get_contract_instance(
-        self, name: ContractName, address: Address, w3: Web3 = None
-    ) -> Contract:
-        """
-        Return a Contract object representing the contract type at the provided address.
-        """
-        validate_contract_name(name)
-        current_w3 = self.get_w3_instance(w3)
-
-        try:
-            self.package_data["contract_types"][name]["abi"]
-        except KeyError:
-            raise InsufficientAssetsError(
-                "Package does not have the ABI required to generate a contract instance "
-                "for contract: {0} at address: {1}.".format(name, address)
-            )
-        contract_kwargs = generate_contract_factory_kwargs(
-            self.package_data["contract_types"][name]
-        )
-        contract_instance = current_w3.eth.contract(address=address, **contract_kwargs)
-        return contract_instance
-
-    def get_w3_instance(self, w3: Web3 = None) -> Web3:
-        """
-        Validate and return the appropriate web3 instance to be used.
-        """
-        current_w3 = None
-        if w3 is not None:
-            current_w3 = w3
-        else:
-            current_w3 = self.w3
-        validate_w3_instance(current_w3)
-        return current_w3
 
     def __repr__(self) -> str:
         name = self.name
         version = self.version
         return "<Package {0}=={1}>".format(name, version)
+
+    @property
+    def name(self) -> str:
+        return self.package_data["package_name"]
+
+    @property
+    def version(self) -> str:
+        return self.package_data["version"]
 
     @classmethod
     def from_file(cls, file_path_or_obj: str, w3: Web3) -> "Package":
@@ -138,7 +94,7 @@ class Package(object):
         return cls(package_data, w3)
 
     @classmethod
-    def from_ipfs(cls, ipfs_uri: str) -> "Package":
+    def from_ipfs(cls, ipfs_uri: str, w3: Web3) -> "Package":
         """
         Instantiate and return a Package object from an IPFS URI pointing to a manifest.
         """
@@ -153,7 +109,7 @@ class Package(object):
                 )
             )
 
-        return cls(package_data)
+        return cls(package_data, w3)
 
     @classmethod
     def from_registry(cls, registry_uri: str, w3: Web3) -> "Package":
@@ -167,13 +123,48 @@ class Package(object):
         manifest_data = get_manifest_from_content_addressed_uri(manifest_uri)
         return cls(manifest_data, w3)
 
-    @property
-    def name(self) -> str:
-        return self.package_data["package_name"]
+    #
+    # Contracts
+    #
 
-    @property
-    def version(self) -> str:
-        return self.package_data["version"]
+    def get_contract_factory(self, name: ContractName) -> Contract:
+        """
+        API to generate a contract factory class.
+        """
+        validate_contract_name(name)
+        try:
+            contract_data = self.package_data["contract_types"][name]
+            validate_minimal_contract_factory_data(contract_data)
+        except KeyError:
+            raise InsufficientAssetsError(
+                "This package has insufficient package data to generate "
+                "a contract factory for contract:{0}.".format(name)
+            )
+
+        contract_kwargs = generate_contract_factory_kwargs(contract_data)
+        contract_factory = self.w3.eth.contract(**contract_kwargs)
+        return contract_factory
+
+    def get_contract_instance(
+        self, name: ContractName, address: Address, w3: Web3 = None
+    ) -> Contract:
+        """
+        Return a Contract object representing the contract type at the provided address.
+        """
+        validate_contract_name(name)
+
+        try:
+            self.package_data["contract_types"][name]["abi"]
+        except KeyError:
+            raise InsufficientAssetsError(
+                "Package does not have the ABI required to generate a contract instance "
+                "for contract: {0} at address: {1}.".format(name, address)
+            )
+        contract_kwargs = generate_contract_factory_kwargs(
+            self.package_data["contract_types"][name]
+        )
+        contract_instance = self.w3.eth.contract(address=address, **contract_kwargs)
+        return contract_instance
 
     #
     # Build Dependencies
@@ -192,7 +183,7 @@ class Package(object):
         for name, uri in dependencies.items():
             try:
                 validate_build_dependency(name, uri)
-                dependency_package = Package.from_ipfs(uri)
+                dependency_package = Package.from_ipfs(uri, self.w3)
             except PyEthPMError as e:
                 raise FailureToFetchIPFSAssetsError(
                     "Failed to retrieve build dependency: {0} from URI: {1}.\n"
@@ -207,25 +198,21 @@ class Package(object):
     # Deployments
     #
 
-    def get_deployments(self, w3: Web3 = None) -> "Deployments":
+    def get_deployments(self) -> "Deployments":
         """
         API to retrieve instance of deployed contract dependency.
         """
-        if w3 is None:
-            w3 = self.w3
-
-        validate_w3_instance(w3)
         validate_deployments_are_present(self.package_data)
 
         all_blockchain_uris = self.package_data["deployments"].keys()
-        matching_uri = validate_single_matching_uri(all_blockchain_uris, w3)
+        matching_uri = validate_single_matching_uri(all_blockchain_uris, self.w3)
 
         deployments = self.package_data["deployments"][matching_uri]
         all_contract_factories = {
             deployment_data["contract_type"]: self.get_contract_factory(
-                deployment_data["contract_type"], w3
+                deployment_data["contract_type"]
             )
             for deployment_data in deployments.values()
         }
 
-        return Deployments(deployments, all_contract_factories, w3)
+        return Deployments(deployments, all_contract_factories, self.w3)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import json
 
 import pytest
 from web3 import Web3
-from web3.providers.eth_tester import EthereumTesterProvider
 
 from ethpm import V2_PACKAGES_DIR
 from ethpm.utils.chains import create_block_uri, get_chain_id
@@ -30,7 +29,7 @@ MANIFESTS = {name: fetch_manifest(name) for name in PACKAGE_NAMES}
 
 @pytest.fixture
 def w3():
-    w3 = Web3(EthereumTesterProvider())
+    w3 = Web3(Web3.EthereumTesterProvider())
     w3.eth.defaultAccount = w3.eth.accounts[0]
     return w3
 

--- a/tests/ethpm/test_dependencies.py
+++ b/tests/ethpm/test_dependencies.py
@@ -7,15 +7,15 @@ from ethpm.validation import validate_build_dependency
 
 
 @pytest.fixture
-def dependencies(dummy_ipfs_backend, piper_coin_manifest):
+def dependencies(dummy_ipfs_backend, piper_coin_manifest, w3):
     deps = piper_coin_manifest["build_dependencies"]
-    dep_pkgs = {dep: Package.from_ipfs(uri) for dep, uri in deps.items()}
+    dep_pkgs = {dep: Package.from_ipfs(uri, w3) for dep, uri in deps.items()}
     return Dependencies(dep_pkgs)
 
 
 @pytest.fixture
-def safe_math_lib_package(safe_math_manifest):
-    return Package(safe_math_manifest)
+def safe_math_lib_package(safe_math_manifest, w3):
+    return Package(safe_math_manifest, w3)
 
 
 def test_dependencies_implements_getitem(dependencies, safe_math_lib_package):

--- a/tests/ethpm/test_get_build_dependencies.py
+++ b/tests/ethpm/test_get_build_dependencies.py
@@ -26,18 +26,18 @@ def test_get_build_dependencies_with_invalid_uris(
 
 
 def test_get_build_dependencies_without_dependencies_raises_exception(
-    piper_coin_manifest
+    piper_coin_manifest, w3
 ):
     piper_coin_manifest.pop("build_dependencies", None)
-    pkg = Package(piper_coin_manifest)
+    pkg = Package(piper_coin_manifest, w3)
     with pytest.raises(ValidationError):
         pkg.get_build_dependencies()
 
 
 def test_get_build_dependencies_with_empty_dependencies_raises_exception(
-    dummy_ipfs_backend, piper_coin_manifest
+    dummy_ipfs_backend, piper_coin_manifest, w3
 ):
     piper_coin_manifest["build_dependencies"] = {}
-    pkg = Package(piper_coin_manifest)
+    pkg = Package(piper_coin_manifest, w3)
     with pytest.raises(ValidationError):
         pkg.get_build_dependencies()

--- a/tests/ethpm/test_get_deployments.py
+++ b/tests/ethpm/test_get_deployments.py
@@ -6,54 +6,43 @@ from ethpm.exceptions import ValidationError
 
 
 @pytest.fixture
-def matching_package(manifest_with_matching_deployment):
-    return Package(manifest_with_matching_deployment)
-
-
-@pytest.mark.parametrize("notw3", ("notW3", 123, set()))
-def test_get_deployments_with_invalid_w3_raise_exception(notw3, matching_package):
-    with pytest.raises(ValueError):
-        matching_package.get_deployments(notw3)
-
-
-def test_get_deployments_without_w3_arg_or_default_raises_exception(matching_package):
-    with pytest.raises(ValueError):
-        matching_package.get_deployments()
+def matching_package(manifest_with_matching_deployment, w3):
+    return Package(manifest_with_matching_deployment, w3)
 
 
 def test_get_deployments_with_empty_deployment_raise_exception(
     w3, manifest_with_empty_deployments
 ):
-    package = Package(manifest_with_empty_deployments)
+    package = Package(manifest_with_empty_deployments, w3)
     with pytest.raises(ValidationError):
-        package.get_deployments(w3)
+        package.get_deployments()
 
 
 def test_get_deployments_with_no_deployments_raises_exception(
     w3, manifest_with_no_deployments
 ):
-    package = Package(manifest_with_no_deployments)
+    package = Package(manifest_with_no_deployments, w3)
     with pytest.raises(ValidationError):
-        package.get_deployments(w3)
+        package.get_deployments()
 
 
 def test_get_deployments_with_no_match_raises_exception(
-    w3, manifest_with_no_matching_deployments
+    manifest_with_no_matching_deployments, w3
 ):
-    package = Package(manifest_with_no_matching_deployments)
+    package = Package(manifest_with_no_matching_deployments, w3)
     with pytest.raises(ValidationError):
-        package.get_deployments(w3)
+        package.get_deployments()
 
 
 def test_get_deployments_with_multiple_matches_raises_exception(
-    w3, manifest_with_multiple_matches
+    manifest_with_multiple_matches, w3
 ):
-    package = Package(manifest_with_multiple_matches)
+    package = Package(manifest_with_multiple_matches, w3)
     with pytest.raises(ValidationError):
-        package.get_deployments(w3)
+        package.get_deployments()
 
 
 def test_get_deployments_with_a_match_returns_deployments(w3, matching_package):
-    deployment = matching_package.get_deployments(w3)
+    deployment = matching_package.get_deployments()
     assert isinstance(deployment, Deployments)
     assert "SafeMathLib" in deployment

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -1,19 +1,19 @@
 from eth_utils import is_same_address
 import pytest
+from web3 import Web3
 
 from ethpm.exceptions import InsufficientAssetsError
 from ethpm.package import Package
 
 
 @pytest.fixture()
-def safe_math_package(get_manifest):
+def safe_math_package(get_manifest, w3):
     safe_math_manifest = get_manifest("safe-math-lib")
-    return Package(safe_math_manifest)
+    return Package(safe_math_manifest, w3)
 
 
 @pytest.fixture()
 def deployed_safe_math(safe_math_package, w3):
-    safe_math_package.set_default_w3(w3)
     SafeMath = safe_math_package.get_contract_factory("SafeMathLib")
     tx_hash = SafeMath.constructor().transact()
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
@@ -26,21 +26,14 @@ def test_package_object_instantiates_with_a_web3_object(all_manifests, w3):
 
 
 def test_set_default_web3(all_manifests, w3):
-    current_package = Package(all_manifests)
-    current_package.set_default_w3(w3)
+    new_w3 = Web3(Web3.EthereumTesterProvider())
+    current_package = Package(all_manifests, w3)
     assert current_package.w3 is w3
-
-
-def test_get_contract_factory_with_unique_web3(safe_math_package, w3):
-    contract_factory = safe_math_package.get_contract_factory("SafeMathLib", w3)
-    assert hasattr(contract_factory, "address")
-    assert hasattr(contract_factory, "abi")
-    assert hasattr(contract_factory, "bytecode")
-    assert hasattr(contract_factory, "bytecode_runtime")
+    current_package.set_default_w3(new_w3)
+    assert current_package.w3 is new_w3
 
 
 def test_get_contract_factory_with_default_web3(safe_math_package, w3):
-    safe_math_package.set_default_w3(w3)
     contract_factory = safe_math_package.get_contract_factory("SafeMathLib")
     assert hasattr(contract_factory, "address")
     assert hasattr(contract_factory, "abi")
@@ -48,27 +41,15 @@ def test_get_contract_factory_with_default_web3(safe_math_package, w3):
     assert hasattr(contract_factory, "bytecode_runtime")
 
 
-@pytest.mark.parametrize("invalid_w3", ({"invalid": "w3"}))
-def test_get_contract_factory_throws_with_invalid_web3(safe_math_package, invalid_w3):
-    with pytest.raises(ValueError):
-        safe_math_package.get_contract_factory("SafeMathLib", invalid_w3)
-
-
-def test_get_contract_factory_without_default_web3(safe_math_package):
-    with pytest.raises(ValueError):
-        assert safe_math_package.get_contract_factory("SafeMathLib")
-
-
 def test_get_contract_factory_with_missing_contract_types(safe_math_package, w3):
-    safe_math_package.set_default_w3(w3)
     safe_math_package.package_data.pop("contract_types", None)
     with pytest.raises(InsufficientAssetsError):
         assert safe_math_package.get_contract_factory("SafeMathLib")
 
 
-def test_get_contract_factory_throws_if_name_isnt_present(safe_math_package, w3):
+def test_get_contract_factory_throws_if_name_isnt_present(safe_math_package):
     with pytest.raises(InsufficientAssetsError):
-        assert safe_math_package.get_contract_factory("DoesNotExist", w3)
+        assert safe_math_package.get_contract_factory("DoesNotExist")
 
 
 def test_get_contract_instance(deployed_safe_math):

--- a/tests/ethpm/test_package_init_from_file.py
+++ b/tests/ethpm/test_package_init_from_file.py
@@ -52,18 +52,18 @@ def non_json_manifest(tmpdir, request):
         yield file_obj_or_path
 
 
-def test_init_from_minimal_valid_manifest():
+def test_init_from_minimal_valid_manifest(w3):
     minimal_manifest = {
         "package_name": "foo",
         "manifest_version": "2",
         "version": "1.0.0",
     }
 
-    Package(minimal_manifest)
+    Package(minimal_manifest, w3)
 
 
-def test_package_init_for_all_manifest_use_cases(all_manifests):
-    package = Package(all_manifests)
+def test_package_init_for_all_manifest_use_cases(all_manifests, w3):
+    package = Package(all_manifests, w3)
     assert isinstance(package, Package)
 
 
@@ -74,14 +74,14 @@ def test_package_init_for_manifest_with_build_dependency(
     assert isinstance(pkg, Package)
 
 
-def test_init_from_invalid_manifest_data():
+def test_init_from_invalid_manifest_data(w3):
     with pytest.raises(ValidationError):
-        Package({})
+        Package({}, w3)
 
 
-def test_init_from_invalid_argument_type():
+def test_init_from_invalid_argument_type(w3):
     with pytest.raises(TypeError):
-        Package("not a manifest")
+        Package("not a manifest", w3)
 
 
 def test_from_file_fails_with_missing_filepath(tmpdir, w3):

--- a/tests/ethpm/test_package_init_from_ipfs.py
+++ b/tests/ethpm/test_package_init_from_ipfs.py
@@ -6,8 +6,8 @@ from ethpm.exceptions import UriNotSupportedError
 VALID_IPFS_PKG = "ipfs://QmeD2s7KaBUoGYTP1eutHBmBkMMMoycdfiyGMx2DKrWXyV"
 
 
-def test_package_from_ipfs_with_valid_uri(dummy_ipfs_backend):
-    package = Package.from_ipfs(VALID_IPFS_PKG)
+def test_package_from_ipfs_with_valid_uri(dummy_ipfs_backend, w3):
+    package = Package.from_ipfs(VALID_IPFS_PKG, w3)
     assert package.name == "safe-math-lib"
     assert isinstance(package, Package)
 
@@ -23,6 +23,6 @@ def test_package_from_ipfs_with_valid_uri(dummy_ipfs_backend):
         "ipfsQmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
     ),
 )
-def test_package_from_ipfs_rejects_invalid_ipfs_uri(invalid):
+def test_package_from_ipfs_rejects_invalid_ipfs_uri(invalid, w3):
     with pytest.raises(UriNotSupportedError):
-        Package.from_ipfs(invalid)
+        Package.from_ipfs(invalid, w3)

--- a/tests/ethpm/utils/test_manifest_validation_utils.py
+++ b/tests/ethpm/utils/test_manifest_validation_utils.py
@@ -38,7 +38,7 @@ def test_validate_deployed_contracts_present_validates(
         validate_manifest_deployments(manifest_with_conflicting_deployments)
 
 
-def test_validate_deployments(manifest_with_matching_deployment):
+def test_validate_deployments(manifest_with_matching_deployment, w3):
     validate = validate_manifest_deployments(manifest_with_matching_deployment)
     assert validate is None
 


### PR DESCRIPTION
### What was wrong?
Optional `w3` upon `package` instantiation became unwieldy - a la discussion in #67 

### How was it fixed?
Instead of making a `w3` instance optional upon `Package` instantiation, require it whenever creating a Package object

- I left `Package.set_default_w3` so that you can change the default `w3` instance - which seems like something we want? (ie. to switch chains to fetch a certain deployment??)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/42837539-940a7166-89bb-11e8-9c63-bb70700ba453.png)

