### PR TITLE
Replace standalone manifests only in testing with all manifests

### DIFF
--- a/ethpm/utils/manifest_validation.py
+++ b/ethpm/utils/manifest_validation.py
@@ -1,7 +1,6 @@
-import itertools
 import json
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List, Set
 
 from jsonschema import ValidationError as jsonValidationError, validate
 
@@ -14,6 +13,15 @@ MANIFEST_SCHEMA_PATH = str(SPEC_DIR / "package.spec.json")
 def _load_schema_data() -> Dict[str, Any]:
     with open(MANIFEST_SCHEMA_PATH) as schema:
         return json.load(schema)
+
+
+def extract_contract_types_from_deployments(deployment_data: List[Any]) -> Set[str]:
+    contract_types = set(
+        deployment["contract_type"]
+        for chain_deployments in deployment_data
+        for deployment in chain_deployments.values()
+    )
+    return contract_types
 
 
 def validate_manifest_against_schema(manifest: Dict[str, Any]) -> None:
@@ -54,10 +62,7 @@ def validate_manifest_deployments(manifest: Dict[str, Any]) -> None:
     if set(("contract_types", "deployments")).issubset(manifest):
         all_contract_types = list(manifest["contract_types"].keys())
         all_deployments = list(manifest["deployments"].values())
-        all_deployment_names = set(
-            itertools.chain.from_iterable(deployment for deployment in all_deployments)
-        )
-
+        all_deployment_names = extract_contract_types_from_deployments(all_deployments)
         missing_contract_types = set(all_deployment_names).difference(
             all_contract_types
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,10 +50,9 @@ def get_manifest():
     return _get_manifest
 
 
-@pytest.fixture
-def all_manifests(get_manifest):
-    manifests = [get_manifest(name) for name in PACKAGE_NAMES]
-    return manifests
+@pytest.fixture(params=PACKAGE_NAMES)
+def all_manifests(request, get_manifest):
+    return get_manifest(request.param)
 
 
 # safe-math-lib currently used as default manifest for testing
@@ -72,15 +71,6 @@ def piper_coin_manifest():
 @pytest.fixture
 def standard_token_manifest():
     return get_manifest("standard-token")
-
-
-# standalone = no `build_dependencies` which aren't fully supported yet
-@pytest.fixture
-def all_standalone_manifests(all_manifests):
-    standalone_manifests = [
-        mnfst for mnfst in all_manifests if "build_dependencies" not in mnfst
-    ]
-    return standalone_manifests
 
 
 @pytest.fixture

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -20,17 +20,15 @@ def deployed_safe_math(safe_math_package, w3):
     return safe_math_package, tx_receipt.contractAddress
 
 
-def test_package_object_instantiates_with_a_web3_object(all_standalone_manifests, w3):
-    for manifest in all_standalone_manifests:
-        current_package = Package(manifest, w3)
-        assert current_package.w3 is w3
+def test_package_object_instantiates_with_a_web3_object(all_manifests, w3):
+    current_package = Package(all_manifests, w3)
+    assert current_package.w3 is w3
 
 
-def test_set_default_web3(all_standalone_manifests, w3):
-    for manifest in all_standalone_manifests:
-        current_package = Package(manifest)
-        current_package.set_default_w3(w3)
-        assert current_package.w3 is w3
+def test_set_default_web3(all_manifests, w3):
+    current_package = Package(all_manifests)
+    current_package.set_default_w3(w3)
+    assert current_package.w3 is w3
 
 
 def test_get_contract_factory_with_unique_web3(safe_math_package, w3):

--- a/tests/ethpm/test_package_init_from_file.py
+++ b/tests/ethpm/test_package_init_from_file.py
@@ -62,11 +62,9 @@ def test_init_from_minimal_valid_manifest():
     Package(minimal_manifest)
 
 
-# only standalone packages are currently supported
-# update test to all use cases when dependent packages are supported
-def test_package_init_for_all_manifest_use_cases(all_standalone_manifests):
-    for manifest in all_standalone_manifests:
-        Package(manifest)
+def test_package_init_for_all_manifest_use_cases(all_manifests):
+    package = Package(all_manifests)
+    assert isinstance(package, Package)
 
 
 def test_package_init_for_manifest_with_build_dependency(

--- a/tests/ethpm/utils/test_manifest_validation_utils.py
+++ b/tests/ethpm/utils/test_manifest_validation_utils.py
@@ -3,6 +3,7 @@ import pytest
 from ethpm import V2_PACKAGES_DIR
 from ethpm.exceptions import ValidationError
 from ethpm.utils.manifest_validation import (
+    extract_contract_types_from_deployments,
     validate_manifest_against_schema,
     validate_manifest_deployments,
     validate_manifest_exists,
@@ -22,8 +23,7 @@ def test_validate_manifest_exists_invalidates():
 
 
 def test_validate_manifest_against_all_manifest_types(all_manifests):
-    for pkg in all_manifests:
-        assert validate_manifest_against_schema(pkg) is None
+    assert validate_manifest_against_schema(all_manifests) is None
 
 
 def test_validate_manifest_invalidates(invalid_manifest):
@@ -46,3 +46,19 @@ def test_validate_deployments(manifest_with_matching_deployment):
 def test_validate_deployed_contracts_pr(manifest_with_no_deployments):
     validate = validate_manifest_deployments(manifest_with_no_deployments)
     assert validate is None
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    (
+        ({}, set()),
+        ([{"some": {"contract_type": "one"}}], set(["one"])),
+        (
+            [{"some": {"contract_type": "one"}, "other": {"contract_type": "two"}}],
+            set(["one", "two"]),
+        ),
+    ),
+)
+def test_extract_contract_types_from_deployments(data, expected):
+    actual = extract_contract_types_from_deployments(data)
+    assert actual == expected


### PR DESCRIPTION
### What was wrong?
Some tests were only using standalone manifests

### How was it fixed?
Changed fixture from `all_standalone_manifests` to `all_manifests`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/42854314-8b025a56-89f8-11e8-98f8-6bc6edd54014.png)
