### PR TITLE
Use new types from eth-typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Python implementation of the [Ethereum Package Manager Specification](http://e
 
 Read more in the documentation on [ReadTheDocs](https://py-ethpm.readthedocs.io/en/latest/).
 
-WARNING
+WARNING!
 
 `Py-EthPM` is currently in public alpha. *Keep in mind*:
 - It is expected to have bugs and is not meant to be used in production

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict
 
-from eth_typing import Address
+from eth_typing import Address, ContractName
 from eth_utils import to_text
 from web3 import Web3
 from web3.eth import Contract
@@ -15,7 +15,6 @@ from ethpm.exceptions import (
     PyEthPMError,
     UriNotSupportedError,
 )
-from ethpm.typing import ContractName
 from ethpm.utils.cache import cached_property
 from ethpm.utils.contract import (
     generate_contract_factory_kwargs,

--- a/ethpm/typing/__init__.py
+++ b/ethpm/typing/__init__.py
@@ -1,1 +1,0 @@
-from .misc import ContractName, URI  # noqa: F401

--- a/ethpm/typing/misc.py
+++ b/ethpm/typing/misc.py
@@ -1,5 +1,0 @@
-from typing import NewType
-
-ContractName = NewType("ContractName", str)
-
-URI = NewType("URI", str)

--- a/ethpm/utils/chains.py
+++ b/ethpm/utils/chains.py
@@ -3,10 +3,9 @@ from typing import Tuple
 from urllib import parse
 
 from cytoolz import curry
+from eth_typing import URI
 from eth_utils import add_0x_prefix, encode_hex, remove_0x_prefix
 from web3 import Web3
-
-from ethpm.typing import URI
 
 
 def get_chain_id(web3: Web3) -> str:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'bumpversion>=0.5.3,<1',
         'eth-keys>=0.2.0b3,<1',
         'eth-tester[py-evm]==0.1.0-beta.26',
-        'eth-typing>=1.0.0,<2',
+        'eth-typing>=1.1.0,<2',
         'eth-utils>=1.0.2,<2',
         'ipfsapi>=0.4.3,<1',
         'jsonschema>=2.6.0,<3',


### PR DESCRIPTION
### What was wrong?
Remove typing module and use types newly added to `eth-typing`



#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/43910791-630c5ea2-9bc3-11e8-8ad7-f06a2484b195.png)

