### PR TITLE
Add IPFS node to circle environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,17 @@ common: &common
         name: install submodules
         command: git submodule update --init
     - run:
+        name: install ipfs
+        command:
+          wget https://dist.ipfs.io/go-ipfs/v0.4.11/go-ipfs_v0.4.11_linux-amd64.tar.gz &&
+          tar xvfz go-ipfs_v0.4.11_linux-amd64.tar.gz &&
+          sudo cp go-ipfs/ipfs /usr/local/bin && 
+          ipfs init
+    - run:
+        name: start ipfs node in background
+        command: ipfs daemon
+        background: true
+    - run:
         name: merge pull request base
         command: |
           if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
@@ -44,7 +55,7 @@ common: &common
           fi
     - run:
         name: run tox
-        command: ~/.local/bin/tox
+        command: ~/.local/bin/tox -- --integration
     - save_cache:
         paths:
           - .tox

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ If for some reason it is not working, add `--recreate` params.
 pytest tests/ethpm/utils/test_uri_utils.py
 ```
 
+IPFS integration tests (`tests/ethpm/integration/`) require a direct connection to an IPFS node and are skipped by default (except in CircleCI, where they are run). To include these tests in your test run, first start an IPFS node and then add `--integration` to the pytest command.
+
 ### Release setup
 
 For Debian-like systems:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,10 @@ PACKAGE_NAMES = [
 ]
 
 
+def pytest_addoption(parser):
+    parser.addoption("--integration", action="store_true", default=False)
+
+
 def fetch_manifest(name):
     with open(str(V2_PACKAGES_DIR / name / "1.0.0.json")) as file_obj:
         return json.load(file_obj)

--- a/tests/ethpm/backends/test_ipfs_backends.py
+++ b/tests/ethpm/backends/test_ipfs_backends.py
@@ -102,12 +102,3 @@ def test_get_uri_backend_with_env_variable(dummy_ipfs_backend, monkeypatch):
     )
     backend = get_ipfs_backend()
     assert isinstance(backend, LocalIPFSBackend)
-
-
-def test_pin_assets_to_infura_backend(fake_client):
-    backend = get_ipfs_backend()
-    backend.client = fake_client
-    hashes = backend.pin_assets(OWNED_MANIFEST_PATH)
-    asset_data = hashes[0]
-    assert asset_data["Name"] == "1.0.0.json"
-    assert asset_data["Hash"] == "QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW"

--- a/tests/ethpm/integration/test_ipfs_integration.py
+++ b/tests/ethpm/integration/test_ipfs_integration.py
@@ -1,0 +1,28 @@
+import pytest
+
+from ethpm import V2_PACKAGES_DIR
+from ethpm.backends.ipfs import get_ipfs_backend
+
+OWNED_MANIFEST_PATH = V2_PACKAGES_DIR / "owned" / "1.0.0.json"
+
+
+def test_local_ipfs_backend_integration_round_trip(monkeypatch):
+    """
+    To run this integration test requires an running IPFS node.
+    If you want to run these tests, first start your IPFS node, and
+    then run pytest with the arg `--integration`.
+    """
+    if not pytest.config.getoption("--integration"):
+        pytest.skip("Not asked to run integration tests")
+
+    monkeypatch.setenv(
+        "ETHPM_IPFS_BACKEND_CLASS", "ethpm.backends.ipfs.LocalIPFSBackend"
+    )
+    backend = get_ipfs_backend()
+    [asset_data] = backend.pin_assets(OWNED_MANIFEST_PATH)
+    assert asset_data["Name"] == "1.0.0.json"
+    assert asset_data["Hash"] == "QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW"
+    with open(str(OWNED_MANIFEST_PATH), "rb") as f:
+        local_manifest = f.read()
+    ipfs_manifest = backend.fetch_uri_contents(asset_data["Hash"])
+    assert ipfs_manifest == local_manifest

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ passenv=
     SOLC_BINARY
     LD_LIBRARY_PATH
 commands=
-    pytest {posargs:tests}
+    pytest tests/ {posargs:tests}
 	doctest: make -C {toxinidir}/docs doctest
 extras=
 	test


### PR DESCRIPTION
### What was wrong?
Better testing of IPFS integration was needed. 

### How was it fixed?
Configured circle to start a ci node in the background we can run some integration tests against

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/43973653-c1c17772-9c9d-11e8-8ccd-e990c2853fbf.png)

