### PR TITLE
Force canonicalized addresses everywhere

### DIFF
--- a/ethpm/contract.py
+++ b/ethpm/contract.py
@@ -6,7 +6,7 @@ from web3.contract import Contract
 from web3.utils.decorators import combomethod
 
 from ethpm.exceptions import BytecodeLinkingError, ValidationError
-from ethpm.validation import validate_empty_bytes
+from ethpm.validation import validate_address, validate_empty_bytes
 
 
 class LinkableContract(Contract):
@@ -24,6 +24,7 @@ class LinkableContract(Contract):
             raise BytecodeLinkingError(
                 "Contract cannot be instantiated until its bytecode is linked."
             )
+        validate_address(address)
         super(LinkableContract, self).__init__(address=address, **kwargs)
 
     @combomethod

--- a/ethpm/deployments.py
+++ b/ethpm/deployments.py
@@ -1,6 +1,6 @@
 from typing import Dict, ItemsView, List
 
-from eth_utils import to_bytes
+from eth_utils import to_canonical_address
 from web3.eth import Contract
 from web3.main import Web3
 
@@ -49,7 +49,7 @@ class Deployments:
         """
         self._validate_name_and_references(contract_name)
         factory = self.contract_factories[contract_name]
-        address = to_bytes(hexstr=self.deployment_data[contract_name]["address"])
+        address = to_canonical_address(self.deployment_data[contract_name]["address"])
         contract_kwargs = {
             "abi": factory.abi,
             "bytecode": factory.bytecode,

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -30,7 +30,7 @@ from ethpm.utils.manifest_validation import (
     validate_manifest_against_schema,
     validate_manifest_deployments,
 )
-from ethpm.validation import validate_build_dependency
+from ethpm.validation import validate_address, validate_build_dependency
 
 
 class Package(object):
@@ -131,6 +131,7 @@ class Package(object):
         """
         Return a Contract object representing the contract type at the provided address.
         """
+        validate_address(address)
         validate_contract_name(name)
         try:
             self.package_data["contract_types"][name]["abi"]

--- a/ethpm/validation.py
+++ b/ethpm/validation.py
@@ -1,12 +1,26 @@
 import re
+from typing import Any
 from urllib import parse
 
-from eth_utils import is_checksum_address
+from eth_utils import is_address, is_canonical_address, is_checksum_address
 
 from ethpm.constants import PACKAGE_NAME_REGEX, REGISTRY_URI_SCHEME
 from ethpm.exceptions import ValidationError
 from ethpm.utils.ipfs import is_ipfs_uri
 from ethpm.utils.registry import is_ens_domain
+
+
+def validate_address(address: Any) -> None:
+    """
+    Raise a ValidationError if an address is not canonicalized.
+    """
+    if not is_address(address):
+        raise ValidationError("Expected an address, got: {0}".format(address))
+    if not is_canonical_address(address):
+        raise ValidationError(
+            "Py-EthPM library only accepts canonicalized addresses. "
+            "{0} is not in the accepted format.".format(address)
+        )
 
 
 def validate_empty_bytes(offset: int, length: int, bytecode: bytes) -> None:

--- a/tests/ethpm/integration/test_escrow_manifest.py
+++ b/tests/ethpm/integration/test_escrow_manifest.py
@@ -35,7 +35,7 @@ def test_deployed_escrow_and_safe_send(escrow_manifest, compiled_safe_send, w3):
         "0x4F5B11c860b37b68DE6D14Fb7e7b5f18A9A1bdC0"
     ).transact()
     escrow_tx_receipt = w3.eth.waitForTransactionReceipt(escrow_tx_hash)
-    escrow_address = escrow_tx_receipt.contractAddress
+    escrow_address = to_canonical_address(escrow_tx_receipt.contractAddress)
 
     # Cannot instantiate a contract instance from an unlinked factory
     with pytest.raises(BytecodeLinkingError):

--- a/tests/ethpm/test_deployments.py
+++ b/tests/ethpm/test_deployments.py
@@ -1,4 +1,4 @@
-from eth_utils import to_bytes
+from eth_utils import to_bytes, to_canonical_address
 import pytest
 from web3.eth import Contract
 
@@ -124,7 +124,7 @@ def test_deployments_get_contract_instance(manifest_with_matching_deployment, w3
     deps = safe_math_package.deployments
     safe_math_instance = deps.get_contract_instance("SafeMathLib")
     assert isinstance(safe_math_instance, Contract)
-    assert safe_math_instance.address == to_bytes(hexstr=address)
+    assert safe_math_instance.address == to_canonical_address(address)
     assert safe_math_instance.bytecode == to_bytes(
         hexstr=safe_math_package.package_data["contract_types"]["SafeMathLib"][
             "deployment_bytecode"

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -1,4 +1,4 @@
-from eth_utils import is_same_address
+from eth_utils import is_same_address, to_canonical_address
 import pytest
 from web3 import Web3
 
@@ -17,7 +17,7 @@ def deployed_safe_math(safe_math_package, w3):
     SafeMath = safe_math_package.get_contract_factory("SafeMathLib")
     tx_hash = SafeMath.constructor().transact()
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
-    return safe_math_package, tx_receipt.contractAddress
+    return safe_math_package, to_canonical_address(tx_receipt.contractAddress)
 
 
 def test_package_object_instantiates_with_a_web3_object(all_manifests, w3):

--- a/tests/ethpm/test_validation_utils.py
+++ b/tests/ethpm/test_validation_utils.py
@@ -1,0 +1,26 @@
+import pytest
+
+from ethpm.exceptions import ValidationError
+from ethpm.validation import validate_address
+
+
+@pytest.mark.parametrize(
+    "address", (b"\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01",)
+)
+def test_validate_address_accepts_canonicalized_addresses(address):
+    result = validate_address(address)
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "address",
+    (
+        "d3cda913deb6f67967b99d67acdfa1712c293601",
+        "0xd3cda913deb6f67967b99d67acdfa1712c293601",
+        "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
+        "\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01xd",
+    ),
+)
+def test_validate_address_rejects_incorrectly_formatted_adresses(address):
+    with pytest.raises(ValidationError):
+        validate_address(address)


### PR DESCRIPTION
### What was wrong?
Use canonicalized addresses everywhere (excepting inside manifests)


### How was it fixed?
Force canonicalized addresses via validation function wherever an address is taken as an argument.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/44673245-2d297a80-a9e8-11e8-9cdf-06463848a448.png)
