### PR TITLE
Remove eth-typing dependency

### DIFF
--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict
 
-from eth_typing import Address, ContractName
 from eth_utils import to_canonical_address, to_text
 from web3 import Web3
 from web3.eth import Contract
@@ -14,6 +13,7 @@ from ethpm.exceptions import (
     InsufficientAssetsError,
     PyEthPMError,
 )
+from ethpm.typing import Address, ContractName
 from ethpm.utils.backend import resolve_uri_contents
 from ethpm.utils.cache import cached_property
 from ethpm.utils.contract import (

--- a/ethpm/typing/__init__.py
+++ b/ethpm/typing/__init__.py
@@ -1,0 +1,1 @@
+from .types import Address, ContractName, URI  # noqa: F401

--- a/ethpm/typing/types.py
+++ b/ethpm/typing/types.py
@@ -1,0 +1,5 @@
+from typing import NewType
+
+Address = NewType("Address", bytes)
+ContractName = NewType("ContractName", str)
+URI = NewType("URI", str)

--- a/ethpm/utils/chains.py
+++ b/ethpm/utils/chains.py
@@ -3,9 +3,10 @@ from typing import Tuple
 from urllib import parse
 
 from cytoolz import curry
-from eth_typing import URI
 from eth_utils import add_0x_prefix, encode_hex, remove_0x_prefix
 from web3 import Web3
+
+from ethpm.typing import URI
 
 
 def get_chain_id(web3: Web3) -> str:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         'bumpversion>=0.5.3,<1',
         'eth-keys>=0.2.0b3,<1',
         'eth-tester[py-evm]==0.1.0-beta.26',
-        'eth-typing>=1.1.0,<2',
         'eth-utils>=1.0.2,<2',
         'ipfsapi>=0.4.3,<1',
         'jsonschema>=2.6.0,<3',


### PR DESCRIPTION
### What was wrong?
Whatever issue is going on with the `eth-typing` dependency, is no longer worth the effort to debug. This is a temporary solution, but since there are only a couple types being imported from `eth-typing`, I'm re-implementing the `typing` module here and adding the types.  


### How was it fixed?



#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/44919424-c1525500-acfa-11e8-87bb-a8f66265c14a.png)

