### PR TITLE
Extend builder and write initial checker

### DIFF
--- a/ethpm/tools/builder.py
+++ b/ethpm/tools/builder.py
@@ -128,6 +128,15 @@ def get_names_and_paths(compiler_output: Dict[str, Any]) -> Dict[str, str]:
     }
 
 
+def source_inliner(compiler_output, package_root_dir=None):
+    return _inline_sources(compiler_output, package_root_dir)
+
+
+@cytoolz.curry
+def _inline_sources(compiler_output, package_root_dir, name):
+    return _inline_source(name, compiler_output, package_root_dir)
+
+
 def inline_source(
     name: str, compiler_output: Dict[str, Any], package_root_dir: Optional[Path] = None
 ) -> Manifest:
@@ -170,6 +179,15 @@ def _inline_source(
         )
 
     return assoc_in(manifest, ["sources", source_path_suffix], source_data)
+
+
+def source_pinner(compiler_output, ipfs_backend, package_root_dir=None):
+    return _pin_sources(compiler_output, ipfs_backend, package_root_dir)
+
+
+@cytoolz.curry
+def _pin_sources(compiler_output, ipfs_backend, package_root_dir, name):
+    return _pin_source(name, compiler_output, ipfs_backend, package_root_dir)
 
 
 def pin_source(
@@ -404,6 +422,24 @@ def validate_link_ref(offset: int, length: int, bytecode: str) -> str:
 
 
 #
+# Helpers
+#
+
+
+@cytoolz.curry
+def init_manifest(package_name, version, manifest_version="2"):
+    """
+    Returns an initial dict with the minimal requried fields for a valid manifest.
+    Should only be used as the first fn to be piped into a `build()` pipeline.
+    """
+    return {
+        "package_name": package_name,
+        "version": version,
+        "manifest_version": manifest_version,
+    }
+
+
+#
 # Formatting
 #
 
@@ -418,7 +454,7 @@ def validate(manifest: Manifest) -> Manifest:
 
 
 @curry
-def return_package(w3: Web3, manifest: Manifest) -> Package:
+def as_package(w3: Web3, manifest: Manifest) -> Package:
     """
     Return a Package object instantiated with the provided manifest and web3 instance.
     """

--- a/tests/ethpm/tools/test_checker.py
+++ b/tests/ethpm/tools/test_checker.py
@@ -1,0 +1,150 @@
+import pytest
+
+from ethpm.tools.checker import (
+    WARNINGS,
+    check_contract_types,
+    check_manifest,
+    check_meta,
+    check_sources,
+)
+
+
+def test_checker_simple():
+    warnings = check_manifest({})
+    assert warnings == {
+        "manifest_version": "Manifest missing a required 'manifest_version' field.",
+        "package_name": "Manifest missing a required 'package_name' field",
+        "version": "Manifest missing a required 'version' field.",
+        "meta": "Manifest missing a suggested 'meta' field.",
+        "sources": """Manifest is missing a sources field, which defines a source tree that """
+        """should comprise the full source tree necessary to recompile the contracts """
+        """contained in this release.""",
+        "contract_types": """Manifest does not contain any 'contract_types'. Packages should """
+        """only include contract types that can be found in the source files for this """
+        """package. Packages should not include contract types from dependencies. """
+        """Packages should not include abstract contracts in the contract types section """
+        """of a release.""",
+    }
+
+
+BASIC_MANIFEST = {
+    "package_name": "package",
+    "version": "1.0.0",
+    "manifest_version": "2",
+}
+
+
+@pytest.mark.parametrize(
+    "manifest,expected",
+    (
+        ({}, {"meta": WARNINGS["meta_missing"]}),
+        ({"meta": {}}, {"meta": WARNINGS["meta_missing"]}),
+        (
+            {"meta": {"x": "x"}},
+            {
+                "meta.authors": WARNINGS["authors_missing"],
+                "meta.description": WARNINGS["description_missing"],
+                "meta.links": WARNINGS["links_missing"],
+                "meta.keywords": WARNINGS["keywords_missing"],
+                "meta.license": WARNINGS["license_missing"],
+            },
+        ),
+    ),
+)
+def test_check_meta(manifest, expected):
+    warnings = check_meta(manifest, {})
+    assert warnings == expected
+
+
+@pytest.mark.parametrize(
+    "manifest,expected",
+    (
+        # Sad paths
+        ({}, {"sources": WARNINGS["sources_missing"]}),
+        ({"sources": []}, {"sources": WARNINGS["sources_missing"]}),
+        # Happy path
+        ({"sources": {"links": "www.github.com"}}, {}),
+    ),
+)
+def test_check_sources(manifest, expected):
+    warnings = check_sources(manifest, {})
+    assert warnings == expected
+
+
+@pytest.mark.parametrize(
+    "manifest,expected",
+    (
+        ({}, {"contract_types": WARNINGS["contract_type_missing"]}),
+        ({"contract_types": {}}, {"contract_types": WARNINGS["contract_type_missing"]}),
+        (
+            {"contract_types": {"x": {"runtime_bytecode": {"invalid": "invalid"}}}},
+            {
+                "contract_types": {
+                    "x": {
+                        "abi": WARNINGS["abi_missing"].format("x"),
+                        "contract_type": WARNINGS[
+                            "contract_type_subfield_missing"
+                        ].format("x"),
+                        "deployment_bytecode": WARNINGS[
+                            "deployment_bytecode_missing"
+                        ].format("x"),
+                        "runtime_bytecode": WARNINGS[
+                            "bytecode_subfield_missing"
+                        ].format("x", "runtime"),
+                        "natspec": WARNINGS["natspec_missing"].format("x"),
+                        "compiler": WARNINGS["compiler_missing"].format("x"),
+                    }
+                }
+            },
+        ),
+        (
+            {
+                "contract_types": {
+                    "x": {
+                        "deployment_bytecode": [],
+                        "runtime_bytecode": {"bytecode": []},
+                    },
+                    "y": {
+                        "abi": [1],
+                        "deployment_bytecode": [],
+                        "runtime_bytecode": [],
+                    },
+                }
+            },
+            {
+                "contract_types": {
+                    "x": {
+                        "abi": WARNINGS["abi_missing"].format("x"),
+                        "contract_type": WARNINGS[
+                            "contract_type_subfield_missing"
+                        ].format("x"),
+                        "deployment_bytecode": WARNINGS[
+                            "deployment_bytecode_missing"
+                        ].format("x"),
+                        "runtime_bytecode": WARNINGS[
+                            "bytecode_subfield_missing"
+                        ].format("x", "runtime"),
+                        "natspec": WARNINGS["natspec_missing"].format("x"),
+                        "compiler": WARNINGS["compiler_missing"].format("x"),
+                    },
+                    "y": {
+                        "contract_type": WARNINGS[
+                            "contract_type_subfield_missing"
+                        ].format("y"),
+                        "deployment_bytecode": WARNINGS[
+                            "deployment_bytecode_missing"
+                        ].format("y"),
+                        "runtime_bytecode": WARNINGS["runtime_bytecode_missing"].format(
+                            "y"
+                        ),
+                        "natspec": WARNINGS["natspec_missing"].format("y"),
+                        "compiler": WARNINGS["compiler_missing"].format("y"),
+                    },
+                }
+            },
+        ),
+    ),
+)
+def test_check_contract_types(manifest, expected):
+    warnings = check_contract_types(manifest, {})
+    assert warnings == expected


### PR DESCRIPTION
### What was wrong?
- added `pin_sources()` and `inline_sources` fns to builder, to allow for creating a pinner/inliner from which you can pin/inline multiple sources
- added `init_manifest()` to builder for simpler init-ing
- started writing the `checker` tool

### How was it fixed?



#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/45382555-dfa33500-b5c5-11e8-9c6d-38d540277299.png)

