### PR TITLE
Add `needs_bytecode_linking` to `LinkableContract`

### DIFF
--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from eth_utils import to_canonical_address, to_text
 from web3 import Web3
@@ -24,8 +24,8 @@ from ethpm.utils.contract import (
 )
 from ethpm.utils.filesystem import load_package_data_from_file
 from ethpm.utils.manifest_validation import (
+    check_for_deployments,
     validate_build_dependencies_are_present,
-    validate_deployments_are_present,
     validate_manifest_against_schema,
     validate_manifest_deployments,
 )
@@ -190,12 +190,13 @@ class Package(object):
     #
 
     @cached_property
-    def deployments(self) -> "Deployments":
+    def deployments(self) -> Union["Deployments", Dict[None, None]]:
         """
         API to retrieve package deployments available on the current w3-connected chain.
         Cached property (self.deployments) gets busted everytime self.set_default_w3() is called.
         """
-        validate_deployments_are_present(self.package_data)
+        if not check_for_deployments(self.package_data):
+            return {}
 
         all_blockchain_uris = self.package_data["deployments"].keys()
         matching_uri = validate_single_matching_uri(all_blockchain_uris, self.w3)

--- a/ethpm/utils/manifest_validation.py
+++ b/ethpm/utils/manifest_validation.py
@@ -72,12 +72,10 @@ def validate_manifest_against_schema(manifest: Dict[str, Any]) -> None:
         )
 
 
-def validate_deployments_are_present(manifest: Dict[str, Any]) -> None:
-    if "deployments" not in manifest:
-        raise ValidationError("Manifest doesn't have a deployments key.")
-
-    if not manifest["deployments"]:
-        raise ValidationError("Manifest's deployments key is empty.")
+def check_for_deployments(manifest: Dict[str, Any]) -> bool:
+    if "deployments" not in manifest or not manifest["deployments"]:
+        return False
+    return True
 
 
 def validate_build_dependencies_are_present(manifest: Dict[str, Any]) -> None:

--- a/tests/ethpm/integration/test_escrow_manifest.py
+++ b/tests/ethpm/integration/test_escrow_manifest.py
@@ -27,8 +27,6 @@ def test_deployed_escrow_and_safe_send(escrow_manifest, compiled_safe_send, w3):
 
     EscrowPackage = Package(escrow_manifest, w3)
     EscrowFactory = EscrowPackage.get_contract_factory("Escrow")
-    assert EscrowFactory.has_linkable_bytecode()
-    assert EscrowFactory.is_bytecode_linked is False
     LinkedEscrowFactory = EscrowFactory.link_bytecode(
         {"SafeSendLib": safe_send_address}
     )
@@ -50,8 +48,8 @@ def test_deployed_escrow_and_safe_send(escrow_manifest, compiled_safe_send, w3):
     with pytest.raises(BytecodeLinkingError):
         EscrowFactory(escrow_address)
     contract_instance = LinkedEscrowFactory(escrow_address)
-    assert EscrowFactory.is_bytecode_linked is False
-    assert LinkedEscrowFactory.is_bytecode_linked is True
+    assert EscrowFactory.needs_bytecode_linking is True
+    assert LinkedEscrowFactory.needs_bytecode_linking is False
     assert isinstance(contract_instance, web3.contract.Contract)
     assert to_canonical_address(safe_send_address) in LinkedEscrowFactory.bytecode
     assert (

--- a/tests/ethpm/test_get_deployments.py
+++ b/tests/ethpm/test_get_deployments.py
@@ -11,20 +11,16 @@ def matching_package(manifest_with_matching_deployment, w3):
     return Package(manifest, w3)
 
 
-def test_get_deployments_with_empty_deployment_raise_exception(
-    w3, manifest_with_empty_deployments
-):
+def test_get_deployments_with_no_deployments(w3, manifest_with_empty_deployments):
     package = Package(manifest_with_empty_deployments, w3)
-    with pytest.raises(ValidationError):
-        package.deployments
+    assert package.deployments == {}
 
 
 def test_get_deployments_with_no_deployments_raises_exception(
     w3, manifest_with_no_deployments
 ):
     package = Package(manifest_with_no_deployments, w3)
-    with pytest.raises(ValidationError):
-        package.deployments
+    assert package.deployments == {}
 
 
 def test_get_deployments_with_no_match_raises_exception(


### PR DESCRIPTION
### What was wrong?
Handling link references strategy was insufficient for pre-linked contract factories. 

This is needed for the `linker` strategy introduced to `pytest-ethereum` [here]().

### How was it fixed?
Replaced `Contract.has_linkable_bytecode` and `Contract.is_bytecode_linked` with `Contract.needs_bytecode_linking` that will automatically detect if a contract's link references are already linked.

some thoughts on possible improvements...
- option to validate link-refs against an address rather than simply asserting they are not `0`s 
- support partially pre-linked contract factories (right now every link-ref has to be unlinked, otherwise we assume that the factory is entirely linked.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/45696092-04e0f780-bb20-11e8-98e1-79b7eccd824e.png)
