### PR TITLE
Rename get_chain_id to get_genesis_block_hash

### DIFF
--- a/ethpm/utils/chains.py
+++ b/ethpm/utils/chains.py
@@ -9,7 +9,7 @@ from web3 import Web3
 from ethpm.typing import URI
 
 
-def get_chain_id(web3: Web3) -> str:
+def get_genesis_block_hash(web3: Web3) -> str:
     return web3.eth.getBlock(0)["hash"]
 
 


### PR DESCRIPTION
### What was wrong?
`get_chain_id` was an inaccurate name for the util


### How was it fixed?
renamed to `get_genesis_block_hash`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/45776416-0db0f680-bc10-11e8-9468-d9a0836b2dbb.png)

