### PR TITLE
Rename `package.package_data` to `package.manifest`

### DIFF
--- a/ethpm/utils/filesystem.py
+++ b/ethpm/utils/filesystem.py
@@ -8,13 +8,13 @@ def load_json_from_file_path(path: Path) -> Dict[Any, Any]:
         return json.load(f)
 
 
-def load_package_data_from_file(file_obj: IO[str]) -> Dict[str, str]:
+def load_manifest_from_file(file_obj: IO[str]) -> Dict[str, str]:
     """
     Utility function to load package objects
     from file objects passed to Package.from_file
     """
     try:
-        package_data = json.load(file_obj)
+        manifest = json.load(file_obj)
     except json.JSONDecodeError as err:
         raise json.JSONDecodeError(
             "Failed to load package data. File is not a valid JSON document.",
@@ -22,4 +22,4 @@ def load_package_data_from_file(file_obj: IO[str]) -> Dict[str, str]:
             err.pos,
         )
 
-    return package_data
+    return manifest

--- a/tests/ethpm/test_deployments.py
+++ b/tests/ethpm/test_deployments.py
@@ -126,7 +126,7 @@ def test_deployments_get_contract_instance(manifest_with_matching_deployment, w3
     assert isinstance(safe_math_instance, Contract)
     assert safe_math_instance.address == address
     assert safe_math_instance.bytecode == to_bytes(
-        hexstr=safe_math_package.package_data["contract_types"]["SafeMathLib"][
+        hexstr=safe_math_package.manifest["contract_types"]["SafeMathLib"][
             "deployment_bytecode"
         ]["bytecode"]
     )

--- a/tests/ethpm/test_get_build_dependencies.py
+++ b/tests/ethpm/test_get_build_dependencies.py
@@ -18,9 +18,7 @@ def test_get_build_dependencies(dummy_ipfs_backend, piper_coin_pkg, w3):
 def test_get_build_dependencies_with_invalid_uris(
     dummy_ipfs_backend, piper_coin_pkg, w3
 ):
-    piper_coin_pkg.package_data["build_dependencies"][
-        "standard-token"
-    ] = "invalid_ipfs_uri"
+    piper_coin_pkg.manifest["build_dependencies"]["standard-token"] = "invalid_ipfs_uri"
     with pytest.raises(FailureToFetchIPFSAssetsError):
         piper_coin_pkg.build_dependencies
 

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -42,7 +42,7 @@ def test_get_contract_factory_with_default_web3(safe_math_package, w3):
 
 
 def test_get_contract_factory_with_missing_contract_types(safe_math_package, w3):
-    safe_math_package.package_data.pop("contract_types", None)
+    safe_math_package.manifest.pop("contract_types", None)
     with pytest.raises(InsufficientAssetsError):
         assert safe_math_package.get_contract_factory("SafeMathLib")
 
@@ -63,7 +63,7 @@ def test_get_contract_instance_throws_with_insufficient_assets(deployed_safe_mat
     safe_math_package, address = deployed_safe_math
     with pytest.raises(InsufficientAssetsError):
         assert safe_math_package.get_contract_instance("IncorrectLib", address)
-    safe_math_package.package_data["contract_types"]["SafeMathLib"].pop("abi")
+    safe_math_package.manifest["contract_types"]["SafeMathLib"].pop("abi")
     with pytest.raises(InsufficientAssetsError):
         assert safe_math_package.get_contract_instance("SafeMathLib", address)
 


### PR DESCRIPTION
### What was wrong?
Suggested refactor. I've always found the attribute name `package_data` slightly confusing and think renaming it to just `manifest` is easier to understand and helps reinforce the concept/role of a manifest.


### How was it fixed?
Renamed `Package.package_data` to `Package.manifest`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/45931334-1401e400-bf2a-11e8-861e-24f6d430e580.png)


