### PR TITLE
Write to_ipfs function for builder

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -133,7 +133,7 @@ To write a manifest to disk
 
    build(
        ...,
-       to_disk(
+       write_to_disk(
            manifest_root_dir: Optional[Path],
            manifest_name: Optional[str],
            prettify: Optional[bool],
@@ -158,7 +158,7 @@ Defaults
    ...     package_name("owned"),
    ...     manifest_version("2"),
    ...     version("1.0.0"),
-   ...     to_disk(manifest_root_dir=p, manifest_name="manifest.json", prettify=True),
+   ...     write_to_disk(manifest_root_dir=p, manifest_name="manifest.json", prettify=True),
    ... )
    {'package_name': 'owned', 'manifest_version': '2', 'version': '1.0.0'}
    >>> with open(str(p / "manifest.json")) as f:
@@ -169,6 +169,23 @@ Defaults
         "package_name": "owned",
         "version": "1.0.0"
    }
+
+
+To pin a manifest to IPFS
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   build(
+       ...,
+       pin_to_ipfs(
+           backend: BaseIPFSBackend,
+           prettify: Optional[bool],
+       ),
+   )
+
+Pins the active manfiest to disk. Must be the concluding function in a builder set since it returns the IPFS pin data rather than returning the manifest for further processing.
+
 
 To add meta fields
 ~~~~~~~~~~~~~~~~~~

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -61,7 +61,7 @@ class Package(object):
         Set the default Web3 instance.
         """
         validate_w3_instance(w3)
-        # Mechanism to bust cached properties when switching chains
+        # Mechanism to bust cached properties when switching chains.
         if "deployments" in self.__dict__:
             del self.deployments
         if "build_dependencies" in self.__dict__:

--- a/ethpm/utils/backend.py
+++ b/ethpm/utils/backend.py
@@ -6,7 +6,6 @@ from ethpm.backends.base import BaseURIBackend
 from ethpm.backends.ipfs import (
     DummyIPFSBackend,
     InfuraIPFSBackend,
-    IPFSGatewayBackend,
     LocalIPFSBackend,
     get_ipfs_backend_class,
 )
@@ -14,7 +13,6 @@ from ethpm.backends.registry import RegistryURIBackend
 from ethpm.exceptions import CannotHandleURI
 
 URI_BACKENDS = [
-    IPFSGatewayBackend,
     InfuraIPFSBackend,
     DummyIPFSBackend,
     LocalIPFSBackend,

--- a/ethpm/utils/manifest_validation.py
+++ b/ethpm/utils/manifest_validation.py
@@ -6,6 +6,7 @@ from jsonschema import ValidationError as jsonValidationError, validate
 
 from ethpm import SPEC_DIR, V2_PACKAGES_DIR
 from ethpm.exceptions import ValidationError
+from ethpm.typing import Manifest
 
 MANIFEST_SCHEMA_PATH = str(SPEC_DIR / "package.spec.json")
 
@@ -114,3 +115,9 @@ def validate_manifest_exists(manifest_id: str) -> None:
         raise ValidationError(
             "Manifest not found in V2_PACKAGES_DIR with id: {0}".format(manifest_id)
         )
+
+
+def format_manifest(manifest: Manifest, *, prettify: bool) -> str:
+    if prettify:
+        return json.dumps(manifest, sort_keys=True, indent=4)
+    return json.dumps(manifest, sort_keys=True, separators=(",", ":"))

--- a/tests/ethpm/backends/test_ipfs_backends.py
+++ b/tests/ethpm/backends/test_ipfs_backends.py
@@ -9,12 +9,11 @@ from ethpm import V2_PACKAGES_DIR
 from ethpm.backends.ipfs import (
     DummyIPFSBackend,
     InfuraIPFSBackend,
-    IPFSGatewayBackend,
     LocalIPFSBackend,
     get_ipfs_backend,
     get_ipfs_backend_class,
 )
-from ethpm.constants import INFURA_GATEWAY_PREFIX, IPFS_GATEWAY_PREFIX
+from ethpm.constants import INFURA_GATEWAY_PREFIX
 
 OWNED_MANIFEST_PATH = V2_PACKAGES_DIR / "owned" / "1.0.0.json"
 
@@ -37,11 +36,7 @@ def fake_client():
 
 
 @pytest.mark.parametrize(
-    "base_uri,backend",
-    (
-        (IPFS_GATEWAY_PREFIX, IPFSGatewayBackend()),
-        (INFURA_GATEWAY_PREFIX, InfuraIPFSBackend()),
-    ),
+    "base_uri,backend", ((INFURA_GATEWAY_PREFIX, InfuraIPFSBackend()),)
 )
 def test_ipfs_and_infura_gateway_backends_fetch_uri_contents(
     base_uri, backend, safe_math_manifest
@@ -79,7 +74,7 @@ def test_local_ipfs_backend(monkeypatch, fake_client):
     ),
 )
 def test_base_ipfs_gateway_backend_correctly_handles_uri_schemes(uri, expected):
-    backend = IPFSGatewayBackend()
+    backend = InfuraIPFSBackend()
     assert backend.can_resolve_uri(uri) is expected
 
 

--- a/tests/ethpm/tools/test_builder.py
+++ b/tests/ethpm/tools/test_builder.py
@@ -24,9 +24,9 @@ from ethpm.tools.builder import (
     pin_source,
     source_inliner,
     source_pinner,
-    to_disk,
     validate,
     version,
+    write_to_disk,
 )
 
 BASE_MANIFEST = {"package_name": "package", "manifest_version": "2", "version": "1.0.0"}
@@ -102,7 +102,7 @@ def test_builder_writes_manifest_to_disk(manifest_dir):
         package_name("package"),
         manifest_version("2"),
         version("1.0.0"),
-        to_disk(
+        write_to_disk(
             manifest_root_dir=manifest_dir, manifest_name="1.0.0.json", prettify=True
         ),
     )
@@ -114,7 +114,11 @@ def test_builder_writes_manifest_to_disk(manifest_dir):
 def test_builder_to_disk_uses_default_cwd(manifest_dir, monkeypatch):
     monkeypatch.chdir(str(manifest_dir))
     build(
-        {}, package_name("package"), manifest_version("2"), version("1.0.0"), to_disk()
+        {},
+        package_name("package"),
+        manifest_version("2"),
+        version("1.0.0"),
+        write_to_disk(),
     )
     with open(str(manifest_dir / "1.0.0.json")) as f:
         actual_manifest = f.read()
@@ -127,7 +131,7 @@ def test_to_disk_writes_minified_manifest_as_default(manifest_dir):
         package_name("package"),
         manifest_version("2"),
         version("1.0.0"),
-        to_disk(manifest_root_dir=manifest_dir, manifest_name="1.0.0.json"),
+        write_to_disk(manifest_root_dir=manifest_dir, manifest_name="1.0.0.json"),
     )
     with open(str(manifest_dir / "1.0.0.json")) as f:
         actual_manifest = f.read()
@@ -140,7 +144,7 @@ def test_to_disk_uses_default_manifest_name(manifest_dir):
         package_name("package"),
         manifest_version("2"),
         version("1.0.0"),
-        to_disk(manifest_root_dir=manifest_dir),
+        write_to_disk(manifest_root_dir=manifest_dir),
     )
     with open(str(manifest_dir / "1.0.0.json")) as f:
         actual_manifest = f.read()
@@ -148,20 +152,20 @@ def test_to_disk_uses_default_manifest_name(manifest_dir):
 
 
 @pytest.mark.parametrize(
-    "to_disk_fn",
+    "write_to_disk_fn",
     (
-        to_disk(manifest_root_dir=Path("not/a/directory")),
-        to_disk(manifest_name="invalid_name"),
+        write_to_disk(manifest_root_dir=Path("not/a/directory")),
+        write_to_disk(manifest_name="invalid_name"),
     ),
 )
-def test_to_disk_with_invalid_args_raises_exception(manifest_dir, to_disk_fn):
+def test_to_disk_with_invalid_args_raises_exception(manifest_dir, write_to_disk_fn):
     with pytest.raises(ManifestBuildingError):
         build(
             {},
             package_name("package"),
             manifest_version("2"),
             version("1.0.0"),
-            to_disk_fn,
+            write_to_disk_fn,
         )
 
 

--- a/tests/ethpm/utils/test_backend_utils.py
+++ b/tests/ethpm/utils/test_backend_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ethpm.backends.ipfs import InfuraIPFSBackend, IPFSGatewayBackend, LocalIPFSBackend
+from ethpm.backends.ipfs import InfuraIPFSBackend, LocalIPFSBackend
 from ethpm.backends.registry import RegistryURIBackend
 from ethpm.exceptions import CannotHandleURI
 from ethpm.utils.backend import (
@@ -15,7 +15,7 @@ from ethpm.utils.backend import (
     (
         (
             "ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/",
-            (IPFSGatewayBackend, InfuraIPFSBackend, LocalIPFSBackend),
+            (InfuraIPFSBackend, LocalIPFSBackend),
         ),
         ("ercXXX://packages.zeppelinos.eth/erc20?version=1.0.0", ()),
     ),


### PR DESCRIPTION
### What was wrong?
It seemed like a `to_ipfs` function in the builder - that would automatically pin a manifest - would be useful


### How was it fixed?
wrote `to_ipfs` builder function
temporarily deprecated `IPFSGatewayBackend` since it doesn't expose a r&w api


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/45979626-df1a8d80-c00c-11e8-8003-ca69c0feb457.png)

