### PR TITLE
Move get_manifest from assets to tools

### DIFF
--- a/ethpm/assets/__init__.py
+++ b/ethpm/assets/__init__.py
@@ -1,9 +1,0 @@
-import json
-from typing import Any, Dict
-
-from ethpm import ASSETS_DIR
-
-
-def get_manifest(use_case: str, filename: str) -> Dict[str, Any]:
-    with open(str(ASSETS_DIR / use_case / filename)) as f:
-        return json.load(f)

--- a/ethpm/tools/__init__.py
+++ b/ethpm/tools/__init__.py
@@ -1,0 +1,1 @@
+from .get_manifest import get_manifest  # noqa: F401

--- a/ethpm/tools/get_manifest.py
+++ b/ethpm/tools/get_manifest.py
@@ -1,0 +1,9 @@
+import json
+from typing import Any, Dict
+
+from ethpm import ASSETS_DIR
+
+
+def get_manifest(use_case: str, filename: str) -> Dict[str, Any]:
+    with open(str(ASSETS_DIR / use_case / filename)) as f:
+        return json.load(f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from web3 import Web3
 
 from ethpm import V2_PACKAGES_DIR, Package
-from ethpm.assets import get_manifest
+from ethpm.tools import get_manifest
 from ethpm.utils.chains import create_block_uri, get_genesis_block_hash
 
 PACKAGE_NAMES = [


### PR DESCRIPTION
### What was wrong?
Convert `get_manifest` helper from `assets` folder to `tools` folder a la discussion https://github.com/ethereum/web3.py/pull/1073


### How was it fixed?



#### Cute Animal Picture

