### PR TITLE
Deprecate 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,12 +71,6 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: doctest
-  py35:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35
   py36:
     <<: *common
     docker:
@@ -95,6 +89,5 @@ workflows:
   test:
     jobs:
       - doctest
-      - py35
       - py36
       - lint

--- a/ethpm/__init__.py
+++ b/ethpm/__init__.py
@@ -15,7 +15,7 @@ if sys.version_info.major < 3:
 
 ETHPM_DIR = Path(__file__).parent
 ASSETS_DIR = ETHPM_DIR / "assets"
-SPEC_DIR = ASSETS_DIR / "spec"  # type: Path
+SPEC_DIR: Path = ASSETS_DIR / "spec"
 ETHPM_SPEC_DIR = ETHPM_DIR.parent / "ethpm-spec"
 V2_PACKAGES_DIR = ETHPM_SPEC_DIR / "examples"
 

--- a/ethpm/backends/ipfs.py
+++ b/ethpm/backends/ipfs.py
@@ -138,9 +138,8 @@ class DummyIPFSBackend(BaseIPFSBackend):
 
     def fetch_uri_contents(self, ipfs_uri: str) -> bytes:
         pkg_name = MANIFEST_URIS[ipfs_uri]
-        with open(str(V2_PACKAGES_DIR / pkg_name / "1.0.0.json")) as file_obj:
-            contents = file_obj.read()
-        return to_bytes(text=contents)
+        pkg_contents = (V2_PACKAGES_DIR / pkg_name / "1.0.0.json").read_text()
+        return to_bytes(text=pkg_contents)
 
     def can_resolve_uri(self, uri: str) -> bool:
         return uri in MANIFEST_URIS

--- a/ethpm/contract.py
+++ b/ethpm/contract.py
@@ -16,8 +16,8 @@ class LinkableContract(Contract):
     contract factories with link references in their package's manifest.
     """
 
-    deployment_link_refs = []  # type: List[Dict[str, Any]]
-    runtime_link_refs = []  # type: List[Dict[str, Any]]
+    deployment_link_refs: List[Dict[str, Any]] = []
+    runtime_link_refs: List[Dict[str, Any]] = []
     needs_bytecode_linking = None
 
     def __init__(self, address: bytes = None, **kwargs: Any) -> None:
@@ -87,9 +87,9 @@ class LinkableContract(Contract):
         Validates that ContractType keys in attr_dict reference existing manifest ContractTypes.
         """
         attr_dict_names = list(attr_dict.keys())
-        all_link_refs = (
+        all_link_refs: List[Dict[str, Any]] = (
             self.deployment_link_refs + self.runtime_link_refs
-        )  # type: List[Dict[str, Any]]
+        )
         all_link_names = [ref["name"] for ref in all_link_refs]
         if set(attr_dict_names) != set(all_link_names):
             raise BytecodeLinkingError(

--- a/ethpm/tools/get_manifest.py
+++ b/ethpm/tools/get_manifest.py
@@ -5,5 +5,4 @@ from ethpm import ASSETS_DIR
 
 
 def get_manifest(use_case: str, filename: str) -> Dict[str, Any]:
-    with open(str(ASSETS_DIR / use_case / filename)) as f:
-        return json.load(f)
+    return json.loads((ASSETS_DIR / use_case / filename).read_text())

--- a/ethpm/utils/contract.py
+++ b/ethpm/utils/contract.py
@@ -64,8 +64,8 @@ def compile_contracts(contract_name: str, alias: str, paths: List[str]) -> str:
     Compile multiple contracts to bytecode.
     """
     bin_id = "{0}.sol:{0}".format(contract_name)
-    contract_paths = [str(V2_PACKAGES_DIR / alias / path[1:]) for path in paths]
+    contract_paths = [(V2_PACKAGES_DIR / alias / path[1:]) for path in paths]
     compiled_source = compile_files(contract_paths)
-    bin_lookup = str(V2_PACKAGES_DIR / alias / bin_id)
+    bin_lookup = V2_PACKAGES_DIR / alias / bin_id
     compiled_source_bin = compiled_source[bin_lookup]["bin"]
     return compiled_source_bin

--- a/ethpm/utils/ipfs.py
+++ b/ethpm/utils/ipfs.py
@@ -70,7 +70,7 @@ def multihash(value: bytes) -> bytes:
 
 
 def serialize_file(file_path: Path) -> PBNode:
-    file_data = open(str(file_path), "rb").read()
+    file_data = open(file_path, "rb").read()
     file_size = len(file_data)
 
     data_protobuf = Data(

--- a/ethpm/utils/manifest_validation.py
+++ b/ethpm/utils/manifest_validation.py
@@ -1,5 +1,4 @@
 import json
-import os
 from typing import Any, Dict, List, Set
 
 from jsonschema import ValidationError as jsonValidationError, validate
@@ -8,7 +7,7 @@ from ethpm import SPEC_DIR, V2_PACKAGES_DIR
 from ethpm.exceptions import ValidationError
 from ethpm.typing import Manifest
 
-MANIFEST_SCHEMA_PATH = str(SPEC_DIR / "package.spec.json")
+MANIFEST_SCHEMA_PATH = SPEC_DIR / "package.spec.json"
 
 META_FIELDS = {
     "license": str,
@@ -110,8 +109,7 @@ def validate_manifest_exists(manifest_id: str) -> None:
     """
     Validate that manifest with manifest_id exists in V2_PACKAGES_DIR
     """
-    manifest_path = str(V2_PACKAGES_DIR / manifest_id)
-    if not os.path.exists(manifest_path):
+    if not (V2_PACKAGES_DIR / manifest_id).is_file():
         raise ValidationError(
             "Manifest not found in V2_PACKAGES_DIR with id: {0}".format(manifest_id)
         )

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'web3[tester]==4.4.1',
     ],
     setup_requires=['setuptools-markdown'],
-    python_requires='>=3.5, <4',
+    python_requires='>=3.6, <4',
     extras_require=extras_require,
     py_modules=['ethpm'],
     license='MIT',
@@ -78,7 +78,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,8 +69,9 @@ def safe_math_manifest(get_manifest):
 
 @pytest.fixture
 def piper_coin_manifest():
-    with open(str(V2_PACKAGES_DIR / "piper-coin" / "1.0.0-pretty.json")) as file_obj:
-        return json.load(file_obj)
+    return json.loads(
+        (V2_PACKAGES_DIR / "piper-coin" / "1.0.0-pretty.json").read_text()
+    )
 
 
 ESCROW_DEPLOYMENT_BYTECODE = {

--- a/tests/ethpm/integration/test_ipfs_integration.py
+++ b/tests/ethpm/integration/test_ipfs_integration.py
@@ -1,3 +1,4 @@
+from eth_utils import to_bytes
 import pytest
 
 from ethpm import V2_PACKAGES_DIR
@@ -23,8 +24,7 @@ def test_local_ipfs_backend_integration_round_trip(monkeypatch):
     [asset_data] = backend.pin_assets(OWNED_MANIFEST_PATH)
     assert asset_data["Name"] == "1.0.0.json"
     assert asset_data["Hash"] == "QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW"
-    with open(str(OWNED_MANIFEST_PATH), "rb") as f:
-        local_manifest = f.read()
+    local_manifest = to_bytes(text=OWNED_MANIFEST_PATH.read_text())
     ipfs_manifest = backend.fetch_uri_contents(asset_data["Hash"])
     assert ipfs_manifest == local_manifest
 

--- a/tests/ethpm/tools/test_builder.py
+++ b/tests/ethpm/tools/test_builder.py
@@ -35,8 +35,8 @@ BASE_MANIFEST = {"package_name": "package", "manifest_version": "2", "version": 
 @pytest.fixture
 def owned_package():
     root = ASSETS_DIR / "owned"
-    manifest = json.loads(Path(str(root / "1.0.0.json")).read_text())
-    compiler = json.loads(Path(str(root / "owned_compiler_output.json")).read_text())[
+    manifest = json.loads((root / "1.0.0.json").read_text())
+    compiler = json.loads((root / "owned_compiler_output.json").read_text())[
         "contracts"
     ]
     contracts_dir = root / "contracts"
@@ -49,10 +49,10 @@ def owned_package():
 @pytest.fixture
 def standard_token_package():
     root = ASSETS_DIR / "standard-token"
-    manifest = json.loads(Path(str(root / "1.0.0.json")).read_text())
-    compiler = json.loads(
-        Path(str(root / "standard_token_compiler_output.json")).read_text()
-    )["contracts"]
+    manifest = json.loads((root / "1.0.0.json").read_text())
+    compiler = json.loads((root / "standard_token_compiler_output.json").read_text())[
+        "contracts"
+    ]
     contracts_dir = root / "contracts"
     return contracts_dir, manifest, compiler
 
@@ -60,17 +60,17 @@ def standard_token_package():
 @pytest.fixture
 def registry_package():
     root = ASSETS_DIR / "registry"
-    compiler = json.loads(
-        Path(str(root / "registry_compiler_output.json")).read_text()
-    )["contracts"]
+    compiler = json.loads(Path(root / "registry_compiler_output.json").read_text())[
+        "contracts"
+    ]
     contracts_dir = root / "contracts"
-    manifest = json.loads(Path(str(root / "1.0.2.json")).read_text())
+    manifest = json.loads((root / "1.0.2.json").read_text())
     return contracts_dir, manifest, compiler
 
 
 @pytest.fixture
 def manifest_dir(tmpdir):
-    return Path(str(tmpdir.mkdir("sub")))
+    return Path(tmpdir.mkdir("sub"))
 
 
 def test_builder_simple_with_package(w3):
@@ -106,13 +106,12 @@ def test_builder_writes_manifest_to_disk(manifest_dir):
             manifest_root_dir=manifest_dir, manifest_name="1.0.0.json", prettify=True
         ),
     )
-    with open(str(manifest_dir / "1.0.0.json")) as f:
-        actual_manifest = f.read()
+    actual_manifest = (manifest_dir / "1.0.0.json").read_text()
     assert actual_manifest == PRETTY_MANIFEST
 
 
 def test_builder_to_disk_uses_default_cwd(manifest_dir, monkeypatch):
-    monkeypatch.chdir(str(manifest_dir))
+    monkeypatch.chdir(manifest_dir)
     build(
         {},
         package_name("package"),
@@ -120,8 +119,7 @@ def test_builder_to_disk_uses_default_cwd(manifest_dir, monkeypatch):
         version("1.0.0"),
         write_to_disk(),
     )
-    with open(str(manifest_dir / "1.0.0.json")) as f:
-        actual_manifest = f.read()
+    actual_manifest = (manifest_dir / "1.0.0.json").read_text()
     assert actual_manifest == MINIFIED_MANIFEST
 
 
@@ -133,8 +131,7 @@ def test_to_disk_writes_minified_manifest_as_default(manifest_dir):
         version("1.0.0"),
         write_to_disk(manifest_root_dir=manifest_dir, manifest_name="1.0.0.json"),
     )
-    with open(str(manifest_dir / "1.0.0.json")) as f:
-        actual_manifest = f.read()
+    actual_manifest = (manifest_dir / "1.0.0.json").read_text()
     assert actual_manifest == MINIFIED_MANIFEST
 
 
@@ -146,8 +143,7 @@ def test_to_disk_uses_default_manifest_name(manifest_dir):
         version("1.0.0"),
         write_to_disk(manifest_root_dir=manifest_dir),
     )
-    with open(str(manifest_dir / "1.0.0.json")) as f:
-        actual_manifest = f.read()
+    actual_manifest = (manifest_dir / "1.0.0.json").read_text()
     assert actual_manifest == MINIFIED_MANIFEST
 
 
@@ -226,7 +222,7 @@ def test_builder_simple_with_multi_meta_field():
 def test_builder_with_inline_source(owned_package, monkeypatch):
     root, _, compiler_output = owned_package
 
-    monkeypatch.chdir(str(root))
+    monkeypatch.chdir(root)
     manifest = build(BASE_MANIFEST, inline_source("Owned", compiler_output), validate())
 
     expected = assoc(
@@ -244,7 +240,7 @@ def test_builder_with_inline_source(owned_package, monkeypatch):
 def test_builder_with_source_inliner(owned_package, monkeypatch):
     root, _, compiler_output = owned_package
 
-    monkeypatch.chdir(str(root))
+    monkeypatch.chdir(root)
     inliner = source_inliner(compiler_output)
     manifest = build(BASE_MANIFEST, inliner("Owned"), validate())
 
@@ -422,7 +418,7 @@ def test_builder_with_standard_token_manifest(
     root, expected_manifest, compiler_output = standard_token_package
     ipfs_backend = get_ipfs_backend()
 
-    monkeypatch.chdir(str(root))
+    monkeypatch.chdir(root)
     manifest = build(
         {},
         package_name("standard-token"),
@@ -441,7 +437,7 @@ def test_builder_with_link_references(
 ):
     root, expected_manifest, compiler_output = registry_package
     ipfs_backend = get_ipfs_backend()
-    monkeypatch.chdir(str(root))
+    monkeypatch.chdir(root)
     pinner = source_pinner(compiler_output, ipfs_backend)
     manifest = build(
         {},

--- a/tests/ethpm/utils/test_manifest_validation_utils.py
+++ b/tests/ethpm/utils/test_manifest_validation_utils.py
@@ -13,7 +13,7 @@ from ethpm.validation import validate_manifest_version
 
 def test_validate_manifest_exists_validates():
     assert (
-        validate_manifest_exists(str(V2_PACKAGES_DIR / "safe-math-lib" / "1.0.0.json"))
+        validate_manifest_exists(V2_PACKAGES_DIR / "safe-math-lib" / "1.0.0.json")
         is None
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{35,36}
+    py{36}
     lint
-	doctest
+    doctest
 
 [isort]
 combine_as_imports=True
@@ -26,13 +26,12 @@ passenv=
     LD_LIBRARY_PATH
 commands=
     pytest tests/ {posargs:tests}
-	doctest: make -C {toxinidir}/docs doctest
+    doctest: make -C {toxinidir}/docs doctest
 extras=
-	test
-	doctest: doc
+    test
+    doctest: doc
 basepython =
-	doctest: python
-    py35: python3.5
+    doctest: python
     py36: python3.6
 whitelist_externals=make
 
@@ -42,7 +41,7 @@ basepython=python
 deps=flake8
 extras=lint
 commands=
-	flake8 {toxinidir}/tests/ethpm {toxinidir}/ethpm --exclude ethpm/assets
-	mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p ethpm
-	black --check --diff {toxinidir}/ethpm/ --check --diff {toxinidir}/tests/
-	isort --recursive {toxinidir}/ethpm/ {toxinidir}/tests/
+    flake8 {toxinidir}/tests/ethpm {toxinidir}/ethpm --exclude ethpm/assets
+    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p ethpm
+    black --check --diff {toxinidir}/ethpm/ --check --diff {toxinidir}/tests/
+    isort --recursive {toxinidir}/ethpm/ {toxinidir}/tests/


### PR DESCRIPTION
### What was wrong?
Deprecate python 3.5 support, add support for python 3.7


### How was it fixed?



#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/46963680-85cdd900-d063-11e8-9ff3-a821a6c95827.png)

