### PR TITLE
Update builder to allow for missing linkreferences in compiler output

### DIFF
--- a/ethpm/tools/builder.py
+++ b/ethpm/tools/builder.py
@@ -373,13 +373,13 @@ def normalize_contract_type(
 
 @to_dict
 def normalize_bytecode_object(obj: Dict[str, Any]) -> Iterable[Tuple[str, Any]]:
-    if obj["linkReferences"]:
-        yield "link_references", process_link_references(
-            obj["linkReferences"], obj["object"]
-        )
-        yield "bytecode", process_bytecode(obj["linkReferences"], obj["object"])
+    link_references = obj.get("linkReferences")
+    bytecode = obj.get("object")
+    if link_references:
+        yield "link_references", process_link_references(link_references, bytecode)
+        yield "bytecode", process_bytecode(link_references, bytecode)
     else:
-        yield "bytecode", add_0x_prefix(obj["object"])
+        yield "bytecode", add_0x_prefix(bytecode)
 
 
 def process_bytecode(link_refs: Dict[str, Any], bytecode: bytes) -> bytes:


### PR DESCRIPTION
### What was wrong?
Builder's strategy to check for link-refs in compiler output was poor.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/49370047-56e2f380-f6f3-11e8-821b-02ebb2e81c84.png)
