### PR TITLE
Add global setup for doctest

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,3 +166,13 @@ doctest_default_flags = (0
     | doctest.IGNORE_EXCEPTION_DETAIL
     | doctest.NORMALIZE_WHITESPACE
 )
+
+# Setup for autoclassed doctests
+doctest_global_setup = """
+from ethpm import Package, V2_PACKAGES_DIR
+from web3 import Web3
+
+owned_manifest_path = V2_PACKAGES_DIR / 'owned' / '1.0.0.json'
+w3 = Web3(Web3.EthereumTesterProvider())
+OwnedPackage = Package.from_file(owned_manifest_path, w3)
+"""

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,2 +1,21 @@
 Release Notes
 =============
+
+v0.1.4-alpha.10
+---------------
+
+Released January 17th, 2019
+
+- Breaking Changes
+
+  - ``Package.set_default_w3()`` returns new ``Package``
+    instance.
+    - `#139 <https://github.com/ethpm/py-ethpm/pull/139>`_
+  - ``Web3`` dependency updated to ``v5.0.0a3``.
+    - `#137 <https://github.com/ethpm/py-ethpm/pull/137>`_
+
+- Bugfixes
+
+  - ``Builder`` bugfix to account for contract factories.
+    - `#138 <https://github.com/ethpm/py-ethpm/pull/138>`_
+  - Add ``global_doctest_setup`` for autodoc to use.

--- a/ethpm/tools/builder.py
+++ b/ethpm/tools/builder.py
@@ -315,7 +315,7 @@ def contract_type(
     To alias a contract_type, include a kwarg `alias` (i.e. `alias="OwnedAlias"`)
     If only an alias kwarg is provided, all available contract data will be included.
     Kwargs must match fields as defined in the EthPM Spec (except "alias") if user
-        wants to include them in custom contract_type.
+    wants to include them in custom contract_type.
     """
     contract_type_fields = {
         "contract_type": contract_type,
@@ -728,7 +728,7 @@ def write_to_disk(
     Defaults
     - Writes manifest to cwd unless Path is provided as manifest_root_dir.
     - Writes manifest with a filename of Manifest[version].json unless a desired
-      manifest name (which must end in json) is provided as manifest_name.
+    manifest name (which must end in json) is provided as manifest_name.
     - Writes the minified manifest version to disk unless prettify is set to True.
     """
     return _write_to_disk(manifest_root_dir, manifest_name, prettify)


### PR DESCRIPTION
### What was wrong?
Some of the autodoc examples were failing b/c of undefined variables. It seems to me as though `testsetup::` doctest directive won't work for autodoc, and the only workaround is to use `doctest_global_setup` a la [here](https://stackoverflow.com/questions/27231362/sphinx-doctest-vs-autodoc)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/51324240-80b96500-1a6a-11e9-9df7-20b4e273e7af.png)

