### PR TITLE
Remove py-solc dependency and all solidity compilation

### DIFF
--- a/ethpm/utils/contract.py
+++ b/ethpm/utils/contract.py
@@ -1,11 +1,9 @@
 import re
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Dict, Generator, Tuple
 
 from eth_utils import to_dict
-from solc import compile_files
 from web3 import Web3
 
-from ethpm import V2_PACKAGES_DIR
 from ethpm.exceptions import InsufficientAssetsError, ValidationError
 
 
@@ -57,15 +55,3 @@ def generate_contract_factory_kwargs(
             yield "linked_references", tuple(
                 contract_data["runtime_bytecode"]["link_references"]
             )
-
-
-def compile_contracts(contract_name: str, alias: str, paths: List[str]) -> str:
-    """
-    Compile multiple contracts to bytecode.
-    """
-    bin_id = f"{contract_name}.sol:{contract_name}"
-    contract_paths = [(V2_PACKAGES_DIR / alias / path[1:]) for path in paths]
-    compiled_source = compile_files(contract_paths)
-    bin_lookup = V2_PACKAGES_DIR / alias / bin_id
-    compiled_source_bin = compiled_source[bin_lookup]["bin"]
-    return compiled_source_bin

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
         'ipfsapi>=0.4.3,<1',
         'jsonschema>=2.6.0,<3',
         'protobuf>=3.0.0,<4',
-        'py-solc>=3.2.0,<4',
         'rlp>=1.0.1,<2',
         'web3[tester]>=5.0.0a3,<6',
     ],

--- a/tests/ethpm/integration/test_escrow_manifest.py
+++ b/tests/ethpm/integration/test_escrow_manifest.py
@@ -1,25 +1,20 @@
+import json
+
 from eth_utils import to_canonical_address
 import pytest
-from solc import compile_source
 import web3
 
-from ethpm import V2_PACKAGES_DIR, Package
+from ethpm import ASSETS_DIR, Package
 from ethpm.exceptions import BytecodeLinkingError
 
 
-@pytest.fixture
-def compiled_safe_send():
-    safe_send_source = V2_PACKAGES_DIR / "escrow" / "contracts" / "SafeSendLib.sol"
-    safe_send_text = safe_send_source.read_text()
-    compiled_sol = compile_source(safe_send_text)
-    contract_interface = compiled_sol["<stdin>:SafeSendLib"]
-    return contract_interface
-
-
-def test_deployed_escrow_and_safe_send(escrow_manifest, compiled_safe_send, w3):
+def test_deployed_escrow_and_safe_send(escrow_manifest, w3):
     # Deploy a SafeSendLib
+    safe_send_manifest = json.loads((ASSETS_DIR / "escrow" / "1.0.3.json").read_text())
+    safe_send_contract_type = safe_send_manifest["contract_types"]["SafeSendLib"]
     SafeSend = w3.eth.contract(
-        abi=compiled_safe_send["abi"], bytecode=compiled_safe_send["bin"]
+        abi=safe_send_contract_type["abi"],
+        bytecode=safe_send_contract_type["deployment_bytecode"]["bytecode"],
     )
     tx_hash = SafeSend.constructor().transact()
     tx_receipt = w3.eth.getTransactionReceipt(tx_hash)

--- a/tests/ethpm/test_package_init_from_registry_uri.py
+++ b/tests/ethpm/test_package_init_from_registry_uri.py
@@ -1,42 +1,7 @@
 import pytest
-from solc import compile_source
 
 from ethpm import ASSETS_DIR, Package
 from ethpm.exceptions import CannotHandleURI
-
-
-@pytest.fixture()
-def w3_with_registry(w3):
-    # compile registry contract
-    registry_source = ASSETS_DIR / "Registry.sol"
-    reg_text = registry_source.read_text()
-    compiled_sol = compile_source(reg_text)
-    contract_interface = compiled_sol["<stdin>:Registry"]
-    # deploy registry contract
-    Registry = w3.eth.contract(
-        abi=contract_interface["abi"], bytecode=contract_interface["bin"]
-    )
-    tx_hash = Registry.constructor().transact()
-    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
-    address = tx_receipt["contractAddress"]
-    registry = w3.eth.contract(address=address, abi=contract_interface["abi"])
-    # register package on deployed registry
-    registry.functions.registerPackage(
-        b"owned",  # pkg-name
-        "1.0.0",  # version
-        "ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW",  # content-addressed URI
-    ).transact()
-    w3.eth.waitForTransactionReceipt(tx_hash)
-    return w3, address, registry
-
-
-@pytest.mark.skip(reason="todo: deploy registry and publish sample package")
-def test_package_init_from_registry_uri(w3_with_registry):
-    w3, address, registry = w3_with_registry
-    valid_registry_uri = "ercXXX://%s/owned?version=1.0.0" % address
-    pkg = Package.from_uri(valid_registry_uri, w3)
-    assert isinstance(pkg, Package)
-    assert pkg.name == "owned"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?
`py-solc` dependency is no longer necessary/supported, replaced all solidity compilation with equivalent packages.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/51388308-48c52700-1b29-11e9-96ca-48b44cf33729.png)

