### PR TITLE
Support contract aliasing in deployments

### DIFF
--- a/docs/package.rst
+++ b/docs/package.rst
@@ -42,7 +42,7 @@ Methods
 Each ``Package`` exposes the following methods.
 
 .. autoclass:: ethpm.Package
-   :members: from_file, from_uri, set_default_w3, get_contract_factory, get_contract_instance
+   :members: from_file, from_uri, switch_w3, get_contract_factory, get_contract_instance
 
 
 Validation

--- a/docs/package.rst
+++ b/docs/package.rst
@@ -25,7 +25,7 @@ Properties
 Each ``Package`` exposes the following properties.
 
 .. autoclass:: ethpm.Package
-   :members: name, version, manifest_version, __repr__, build_dependencies, deployments
+   :members: name, version, manifest_version, uri, __repr__, build_dependencies, deployments
 
 .. py:attribute:: Package.w3
 

--- a/ethpm/deployments.py
+++ b/ethpm/deployments.py
@@ -48,6 +48,8 @@ class Deployments:
         after validating contract name.
         """
         self._validate_name_and_references(contract_name)
+        # Use a deployment's "contract_type" to lookup contract factory
+        # in case the deployment uses a contract alias
         contract_type = self.deployment_data[contract_name]["contract_type"]
         factory = self.contract_factories[contract_type]
         address = to_canonical_address(self.deployment_data[contract_name]["address"])
@@ -64,12 +66,12 @@ class Deployments:
         if name not in self.deployment_data:
             raise KeyError(
                 "Contract name not found in deployment data. "
-                f"Available deployments include: {list(self.deployment_data.keys())}."
+                f"Available deployments include: {list(sorted(self.deployment_data.keys()))}."
             )
 
         contract_type = self.deployment_data[name]["contract_type"]
         if contract_type not in self.contract_factories:
             raise ValidationError(
                 f"Contract type: {contract_type} for alias: {name} not found. "
-                f"Available contract types include: {list(self.contract_factories.keys())}."
+                f"Available contract types include: {list(sorted(self.contract_factories.keys()))}."
             )

--- a/ethpm/deployments.py
+++ b/ethpm/deployments.py
@@ -48,7 +48,8 @@ class Deployments:
         after validating contract name.
         """
         self._validate_name_and_references(contract_name)
-        factory = self.contract_factories[contract_name]
+        contract_type = self.deployment_data[contract_name]["contract_type"]
+        factory = self.contract_factories[contract_type]
         address = to_canonical_address(self.deployment_data[contract_name]["address"])
         contract_kwargs = {
             "abi": factory.abi,
@@ -61,7 +62,14 @@ class Deployments:
         validate_contract_name(name)
 
         if name not in self.deployment_data:
-            raise KeyError("Contract name not found in deployment data")
+            raise KeyError(
+                "Contract name not found in deployment data. "
+                f"Available deployments include: {list(self.deployment_data.keys())}."
+            )
 
-        if name not in self.contract_factories:
-            raise ValidationError("Contract name not found in contract_factories.")
+        contract_type = self.deployment_data[name]["contract_type"]
+        if contract_type not in self.contract_factories:
+            raise ValidationError(
+                f"Contract type: {contract_type} for alias: {name} not found. "
+                f"Available contract types include: {list(self.contract_factories.keys())}."
+            )

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -65,7 +65,7 @@ class Package(object):
         self.manifest = manifest
         self._uri = uri
 
-    def set_default_w3(self, w3: Web3) -> "Package":
+    def switch_w3(self, w3: Web3) -> "Package":
         """
         Returns a new instance of `Package` containing the same manifest,
         but connected to a different web3 instance.
@@ -73,7 +73,7 @@ class Package(object):
         .. doctest::
 
            >>> new_w3 = Web3(Web3.EthereumTesterProvider())
-           >>> NewPackage = OwnedPackage.set_default_w3(new_w3)
+           >>> NewPackage = OwnedPackage.switch_w3(new_w3)
            >>> assert NewPackage.w3 == new_w3
            >>> assert OwnedPackage.manifest == NewPackage.manifest
         """

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -45,7 +45,7 @@ from ethpm.validation import (
 
 
 class Package(object):
-    def __init__(self, manifest: Dict[str, Any], w3: Web3) -> None:
+    def __init__(self, manifest: Dict[str, Any], w3: Web3, uri: str = None) -> None:
         """
         A package should be created using one of the available
         classmethods and a valid w3 instance.
@@ -63,6 +63,7 @@ class Package(object):
         self.w3 = w3
         self.w3.eth.defaultContractFactory = LinkableContract
         self.manifest = manifest
+        self._uri = uri
 
     def set_default_w3(self, w3: Web3) -> "Package":
         """
@@ -77,7 +78,7 @@ class Package(object):
            >>> assert OwnedPackage.manifest == NewPackage.manifest
         """
         validate_w3_instance(w3)
-        return Package(self.manifest, w3)
+        return Package(self.manifest, w3, self.uri)
 
     def __repr__(self) -> str:
         """
@@ -128,6 +129,13 @@ class Package(object):
         """
         return self.manifest["manifest_version"]
 
+    @property
+    def uri(self) -> str:
+        """
+        The uri (local file_path / content-addressed URI) of a ``Package``'s manifest.
+        """
+        return self._uri
+
     @classmethod
     def from_file(cls, file_path: Path, w3: Web3) -> "Package":
         """
@@ -144,7 +152,7 @@ class Package(object):
                 "The Package.from_file method expects a pathlib.Path instance."
                 f"Got {type(file_path)} instead."
             )
-        return cls(manifest, w3)
+        return cls(manifest, w3, file_path.as_uri())
 
     @classmethod
     def from_uri(cls, uri: str, w3: Web3) -> "Package":
@@ -163,7 +171,7 @@ class Package(object):
         contents = to_text(resolve_uri_contents(uri))
         validate_raw_manifest_format(contents)
         manifest = json.loads(contents)
-        return cls(manifest, w3)
+        return cls(manifest, w3, uri)
 
     #
     # Contracts

--- a/ethpm/utils/chains.py
+++ b/ethpm/utils/chains.py
@@ -2,7 +2,7 @@ import re
 from typing import Tuple
 from urllib import parse
 
-from eth_utils import add_0x_prefix, encode_hex, remove_0x_prefix
+from eth_utils import add_0x_prefix, encode_hex, remove_0x_prefix, to_hex
 from eth_utils.toolz import curry
 from web3 import Web3
 
@@ -100,3 +100,9 @@ def create_BIP122_uri(
 
 def create_block_uri(chain_id: str, block_identifier: str) -> URI:
     return create_BIP122_uri(chain_id, "block", remove_0x_prefix(block_identifier))
+
+
+def create_latest_block_uri(w3: Web3) -> URI:
+    chain_id = to_hex(get_genesis_block_hash(w3))
+    recent_block = to_hex(w3.eth.getBlock("latest")["hash"])
+    return create_block_uri(chain_id, recent_block)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,9 +207,9 @@ def manifest_with_no_matching_deployments(w3, tmpdir, safe_math_manifest):
 @pytest.fixture
 def manifest_with_multiple_matches(w3, tmpdir, safe_math_manifest):
     w3.testing.mine(5)
-    block_uri = create_latest_block_uri(w3)
+    block_uri = create_latest_block_uri(w3, from_blocks_ago=0)
     w3.testing.mine(1)
-    second_block_uri = create_latest_block_uri(w3)
+    second_block_uri = create_latest_block_uri(w3, from_blocks_ago=0)
     manifest = copy.deepcopy(safe_math_manifest)
     manifest["deployments"][block_uri] = {
         "SafeMathLib": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,18 @@
 import copy
 import json
 
+from eth_utils.toolz import assoc_in
 import pytest
 from pytest_ethereum import linker as l  # noqa: E741
 from web3 import Web3
 
 from ethpm import ASSETS_DIR, V2_PACKAGES_DIR, Package
 from ethpm.tools import get_manifest as get_manifest_tool
-from ethpm.utils.chains import create_block_uri, get_genesis_block_hash
+from ethpm.utils.chains import (
+    create_block_uri,
+    create_latest_block_uri,
+    get_genesis_block_hash,
+)
 
 pytest_plugins = ["pytest_ethereum.plugins"]
 
@@ -167,6 +172,21 @@ def safe_math_lib_package(deployer, w3):
 
 
 @pytest.fixture
+def safe_math_lib_package_with_alias(deployer, w3):
+    safe_math_lib_manifest = ASSETS_DIR / "safe-math-lib" / "1.0.1.json"
+    safe_math_deployer = deployer(safe_math_lib_manifest)
+    pkg = safe_math_deployer.deploy("SafeMathLib")
+    blockchain_uri = list(pkg.manifest["deployments"].keys())[0]
+    deployment_data = pkg.manifest["deployments"][blockchain_uri]["SafeMathLib"]
+    aliased_manifest = assoc_in(
+        pkg.manifest,
+        ["deployments", blockchain_uri],
+        {"safe-math-lib-alias": deployment_data},
+    )
+    return Package(aliased_manifest, w3)
+
+
+@pytest.fixture
 def manifest_with_no_matching_deployments(w3, tmpdir, safe_math_manifest):
     w3.testing.mine(5)
     incorrect_genesis_hash = b"\x00" * 31 + b"\x01"
@@ -187,14 +207,9 @@ def manifest_with_no_matching_deployments(w3, tmpdir, safe_math_manifest):
 @pytest.fixture
 def manifest_with_multiple_matches(w3, tmpdir, safe_math_manifest):
     w3.testing.mine(5)
-    genesis_hash = get_genesis_block_hash(w3)
-    block = w3.eth.getBlock("latest")
-    block_uri = create_block_uri(w3.toHex(genesis_hash), w3.toHex(block.hash))
+    block_uri = create_latest_block_uri(w3)
     w3.testing.mine(1)
-    second_block = w3.eth.getBlock("latest")
-    second_block_uri = create_block_uri(
-        w3.toHex(genesis_hash), w3.toHex(second_block.hash)
-    )
+    second_block_uri = create_latest_block_uri(w3)
     manifest = copy.deepcopy(safe_math_manifest)
     manifest["deployments"][block_uri] = {
         "SafeMathLib": {

--- a/tests/ethpm/test_deployments.py
+++ b/tests/ethpm/test_deployments.py
@@ -129,6 +129,17 @@ def test_deployments_get_instance(safe_math_lib_package):
     )
 
 
+def test_deployments_get_instance_with_contract_alias(safe_math_lib_package_with_alias):
+    deps = safe_math_lib_package_with_alias.deployments
+    safe_math_instance = deps.get_instance("safe-math-lib-alias")
+    assert isinstance(safe_math_instance, Contract)
+    assert safe_math_instance.bytecode == to_bytes(
+        hexstr=safe_math_lib_package_with_alias.manifest["contract_types"][
+            "SafeMathLib"
+        ]["deployment_bytecode"]["bytecode"]
+    )
+
+
 def test_deployments_get_instance_with_link_dependency(escrow_package):
     deployments = escrow_package.deployments
     escrow_deployment = deployments.get_instance("Escrow")

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -25,11 +25,11 @@ def test_package_object_instantiates_with_a_web3_object(all_manifests, w3):
     assert package.w3 is w3
 
 
-def test_set_default_web3(deployed_safe_math, w3):
+def test_switch_web3(deployed_safe_math, w3):
     new_w3 = Web3(Web3.EthereumTesterProvider())
     original_package, _ = deployed_safe_math
     assert original_package.w3 is w3
-    new_package = original_package.set_default_w3(new_w3)
+    new_package = original_package.switch_w3(new_w3)
     assert new_package.w3 is new_w3
     assert original_package is not new_package
     assert original_package.manifest == new_package.manifest

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -76,4 +76,5 @@ def test_package_object_properties(safe_math_package):
     assert safe_math_package.name == "safe-math-lib"
     assert safe_math_package.version == "1.0.0"
     assert safe_math_package.manifest_version == "2"
+    assert safe_math_package.uri == None
     assert safe_math_package.__repr__() == "<Package safe-math-lib==1.0.0>"


### PR DESCRIPTION
### What was wrong?
We weren't supporting contract-aliasing in `deployments`


### How was it fixed?
_ Support contract aliasing in `deployments`
_ Created a `create_latest_block_uri` util
_ Added a `uri` property to `Package` b/c I've found it to be useful

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/52436911-c6e66f00-2ad2-11e9-899b-ddc3a9b8641f.png)
