### PR TITLE
Update registry backend to work with web3.pm

### DIFF
--- a/ethpm/__init__.py
+++ b/ethpm/__init__.py
@@ -20,3 +20,5 @@ ETHPM_SPEC_DIR = ETHPM_DIR.parent / "ethpm-spec"
 V2_PACKAGES_DIR = ETHPM_SPEC_DIR / "examples"
 
 from .package import Package  # noqa: F401
+
+from .utils.uri import RegistryURI  # noqa: F401

--- a/ethpm/utils/uri.py
+++ b/ethpm/utils/uri.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import hashlib
 import json
 from typing import Tuple
@@ -9,6 +10,9 @@ import requests
 from ethpm.constants import GITHUB_API_AUTHORITY
 from ethpm.exceptions import CannotHandleURI, ValidationError
 from ethpm.typing import URI
+from ethpm.validation import validate_registry_uri
+
+RegistryURI = namedtuple("RegistryURI", ["auth", "name", "version"])
 
 
 def create_content_addressed_github_uri(uri: URI) -> URI:
@@ -90,3 +94,15 @@ def validate_blob_uri_contents(contents: bytes, blob_uri: str) -> None:
         raise ValidationError(
             f"Hash of contents fetched from {blob_uri} do not match its hash: {blob_hash}."
         )
+
+
+def parse_registry_uri(uri: str) -> RegistryURI:
+    """
+    Validate and return (authority, pkg name, version) from a valid registry URI
+    """
+    validate_registry_uri(uri)
+    parsed_uri = parse.urlparse(uri)
+    authority = parsed_uri.netloc
+    pkg_name = parsed_uri.path.strip("/")
+    pkg_version = parsed_uri.query.lstrip("version=").strip("/")
+    return RegistryURI(authority, pkg_name, pkg_version)

--- a/tests/ethpm/utils/test_uri_utils.py
+++ b/tests/ethpm/utils/test_uri_utils.py
@@ -5,6 +5,7 @@ from ethpm.utils.uri import (
     create_content_addressed_github_uri,
     is_valid_api_github_uri,
     is_valid_content_addressed_github_uri,
+    parse_registry_uri,
 )
 
 
@@ -43,3 +44,23 @@ def test_create_github_uri():
     expected_blob_uri = "https://api.github.com/repos/ethpm/py-ethpm/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03480"
     actual_blob_uri = create_content_addressed_github_uri(api_uri)
     assert actual_blob_uri == expected_blob_uri
+
+
+@pytest.mark.parametrize(
+    "uri,expected",
+    (
+        (
+            "ercXXX://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/owned?version=1.0.0",
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "owned", "1.0.0"],
+        ),
+        (
+            "ercXXX://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/wallet?version=2.8.0/",
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "wallet", "2.8.0"],
+        ),
+    ),
+)
+def test_parse_registry_uri(uri, expected):
+    address, pkg_name, pkg_version = parse_registry_uri(uri)
+    assert address == expected[0]
+    assert pkg_name == expected[1]
+    assert pkg_version == expected[2]


### PR DESCRIPTION
### What was wrong?
`RegistryURIBackend` was written before `web3.pm` so it's been updated to work with the new api.

Wrote a `parse_registry_util` since it's now needed in multiple places

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/55638786-51dca080-57c8-11e9-85f1-107f29e67ad5.png)

