### PR TITLE
Write is_supported_content_addressed_uri

### DIFF
--- a/ethpm/__init__.py
+++ b/ethpm/__init__.py
@@ -1,7 +1,6 @@
+from pathlib import Path
 import sys
 import warnings
-
-from pathlib import Path
 
 
 if sys.version_info.major < 3:
@@ -20,5 +19,4 @@ ETHPM_SPEC_DIR = ETHPM_DIR.parent / "ethpm-spec"
 V2_PACKAGES_DIR = ETHPM_SPEC_DIR / "examples"
 
 from .package import Package  # noqa: F401
-
 from .utils.uri import RegistryURI  # noqa: F401

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -15,7 +15,7 @@ from ethpm.exceptions import (
     InsufficientAssetsError,
     PyEthPMError,
 )
-from ethpm.typing import Address, ContractName
+from ethpm.typing import URI, Address, ContractName
 from ethpm.utils.backend import resolve_uri_contents
 from ethpm.utils.cache import cached_property
 from ethpm.utils.contract import (
@@ -155,7 +155,7 @@ class Package(object):
         return cls(manifest, w3, file_path.as_uri())
 
     @classmethod
-    def from_uri(cls, uri: str, w3: Web3) -> "Package":
+    def from_uri(cls, uri: URI, w3: Web3) -> "Package":
         """
         Returns a Package object instantiated by a manifest located at a content-addressed URI.
         A valid ``Web3`` instance is also required.

--- a/ethpm/tools/builder.py
+++ b/ethpm/tools/builder.py
@@ -459,7 +459,7 @@ def normalize_bytecode_object(obj: Dict[str, Any]) -> Iterable[Tuple[str, Any]]:
         yield "bytecode", add_0x_prefix(bytecode)
 
 
-def process_bytecode(link_refs: Dict[str, Any], bytecode: bytes) -> bytes:
+def process_bytecode(link_refs: Dict[str, Any], bytecode: bytes) -> str:
     """
     Replace link_refs in bytecode with 0's.
     """

--- a/ethpm/typing/__init__.py
+++ b/ethpm/typing/__init__.py
@@ -1,1 +1,1 @@
-from .types import Address, ContractName, HexStr, Manifest, URI  # noqa: F401
+from .types import URI, Address, ContractName, HexStr, Manifest  # noqa: F401

--- a/ethpm/utils/chains.py
+++ b/ethpm/utils/chains.py
@@ -87,14 +87,16 @@ def create_BIP122_uri(
     elif not is_block_or_transaction_hash(chain_id):
         raise ValueError("Invalid chain_id.  Must be a hex encoded 32 byte value")
 
-    return parse.urlunsplit(
-        [
-            "blockchain",
-            remove_0x_prefix(chain_id),
-            f"{resource_type}/{remove_0x_prefix(resource_identifier)}",
-            "",
-            "",
-        ]
+    return URI(
+        parse.urlunsplit(
+            [
+                "blockchain",
+                remove_0x_prefix(chain_id),
+                f"{resource_type}/{remove_0x_prefix(resource_identifier)}",
+                "",
+                "",
+            ]
+        )
     )
 
 

--- a/ethpm/utils/deployments.py
+++ b/ethpm/utils/deployments.py
@@ -29,7 +29,7 @@ def get_linked_deployments(deployments: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def validate_linked_references(
-    link_deps: Tuple[Tuple[int, str]], bytecode: bytes
+    link_deps: Tuple[Tuple[int, bytes], ...], bytecode: bytes
 ) -> None:
     """
     Validates that normalized linked_references (offset, expected_bytes)

--- a/ethpm/utils/uri.py
+++ b/ethpm/utils/uri.py
@@ -10,8 +10,8 @@ import requests
 from ethpm.constants import GITHUB_API_AUTHORITY
 from ethpm.exceptions import CannotHandleURI, ValidationError
 from ethpm.typing import URI
-from ethpm.validation import validate_registry_uri
 from ethpm.utils.ipfs import is_ipfs_uri
+from ethpm.validation import validate_registry_uri
 
 RegistryURI = namedtuple("RegistryURI", ["auth", "name", "version"])
 

--- a/ethpm/utils/uri.py
+++ b/ethpm/utils/uri.py
@@ -11,6 +11,7 @@ from ethpm.constants import GITHUB_API_AUTHORITY
 from ethpm.exceptions import CannotHandleURI, ValidationError
 from ethpm.typing import URI
 from ethpm.validation import validate_registry_uri
+from ethpm.utils.ipfs import is_ipfs_uri
 
 RegistryURI = namedtuple("RegistryURI", ["auth", "name", "version"])
 
@@ -106,3 +107,13 @@ def parse_registry_uri(uri: str) -> RegistryURI:
     pkg_name = parsed_uri.path.strip("/")
     pkg_version = parsed_uri.query.lstrip("version=").strip("/")
     return RegistryURI(authority, pkg_name, pkg_version)
+
+
+def is_supported_content_addressed_uri(uri: URI) -> bool:
+    """
+    Returns a bool indicating whether provided uri is currently supported.
+    Currently Py-EthPM only supports IPFS and Github blob content-addressed uris.
+    """
+    if not is_ipfs_uri(uri) and not is_valid_content_addressed_github_uri(uri):
+        return False
+    return True

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist=
 combine_as_imports=True
 force_sort_within_sections=True
 include_trailing_comma=True
+skip=__init__.py
 known_third_party=pytest,requests_mock
 known_first_party=ethpm
 line_length=88
@@ -44,4 +45,4 @@ commands=
     flake8 {toxinidir}/tests {toxinidir}/ethpm
     mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p ethpm
     black --check --diff {toxinidir}/ethpm/ --check --diff {toxinidir}/tests/
-    isort --recursive {toxinidir}/ethpm/ {toxinidir}/tests/
+    isort --check-only --recursive --diff {toxinidir}/ethpm/ {toxinidir}/tests/


### PR DESCRIPTION
### What was wrong?
Already used this function in both `ethpm-cli` and the ipfs pinner, so it seems like it belongs here.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/56587787-6d2a1700-65e2-11e9-8e4e-75772c9c4297.png)

