### PR TITLE
Update to use new IPFS library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ common: &common
     - run:
         name: install ipfs
         command:
-          wget https://dist.ipfs.io/go-ipfs/v0.4.11/go-ipfs_v0.4.11_linux-amd64.tar.gz &&
-          tar xvfz go-ipfs_v0.4.11_linux-amd64.tar.gz &&
+          wget https://dist.ipfs.io/go-ipfs/v0.4.19/go-ipfs_v0.4.19_linux-amd64.tar.gz &&
+          tar xvfz go-ipfs_v0.4.19_linux-amd64.tar.gz &&
           sudo cp go-ipfs/ipfs /usr/local/bin && 
           ipfs init
     - run:

--- a/ethpm/backends/ipfs.py
+++ b/ethpm/backends/ipfs.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from typing import Dict, List, Type
 
 from eth_utils import import_string, to_bytes
-import ipfsapi
+import ipfshttpclient
 
 from ethpm import ASSETS_DIR
 from ethpm.backends.base import BaseURIBackend
 from ethpm.constants import (
     DEFAULT_IPFS_BACKEND,
-    INFURA_GATEWAY_PREFIX,
+    INFURA_GATEWAY_MULTIADDR,
     IPFS_GATEWAY_PREFIX,
 )
 from ethpm.exceptions import CannotHandleURI, ValidationError
@@ -57,7 +57,7 @@ class IPFSOverHTTPBackend(BaseIPFSBackend):
     """
 
     def __init__(self) -> None:
-        self.client = ipfsapi.connect(self.base_uri, 5001)
+        self.client = ipfshttpclient.connect(self.base_uri)
 
     def fetch_uri_contents(self, uri: str) -> bytes:
         ipfs_hash = extract_ipfs_path_from_uri(uri)
@@ -116,7 +116,7 @@ class InfuraIPFSBackend(IPFSOverHTTPBackend):
 
     @property
     def base_uri(self) -> str:
-        return INFURA_GATEWAY_PREFIX
+        return INFURA_GATEWAY_MULTIADDR
 
 
 class LocalIPFSBackend(IPFSOverHTTPBackend):
@@ -127,7 +127,7 @@ class LocalIPFSBackend(IPFSOverHTTPBackend):
 
     @property
     def base_uri(self) -> str:
-        return "localhost"
+        return "/ip4/127.0.0.1/tcp/5001"
 
 
 MANIFEST_URIS = {

--- a/ethpm/constants.py
+++ b/ethpm/constants.py
@@ -11,6 +11,6 @@ IPFS_GATEWAY_PREFIX = "https://ipfs.io/ipfs/"
 # Please play nice and don't use this key for any shenanigans, thanks!
 INFURA_API_KEY = "4f1a358967c7474aae6f8f4a7698aefc"
 
-INFURA_GATEWAY_PREFIX = "https://ipfs.infura.io"
+INFURA_GATEWAY_MULTIADDR = "/dns4/ipfs.infura.io/tcp/5001/https/"
 
 GITHUB_API_AUTHORITY = "api.github.com"

--- a/ethpm/utils/backend.py
+++ b/ethpm/utils/backend.py
@@ -2,7 +2,7 @@ import logging
 from typing import Generator, Type
 
 from eth_utils import to_tuple
-from ipfsapi.exceptions import ConnectionError
+from ipfshttpclient.exceptions import ConnectionError
 
 from ethpm.backends.base import BaseURIBackend
 from ethpm.backends.http import GithubOverHTTPSBackend

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'eth-utils>=1.4.1,<2',
-        'ipfsapi>=0.4.3,<1',
+        'ipfshttpclient>=0.4.11,<1',
         'jsonschema>=2.6.0,<3',
         'protobuf>=3.0.0,<4',
         'rlp>=1.0.1,<2',

--- a/tests/ethpm/backends/test_ipfs_backends.py
+++ b/tests/ethpm/backends/test_ipfs_backends.py
@@ -12,7 +12,7 @@ from ethpm.backends.ipfs import (
     get_ipfs_backend,
     get_ipfs_backend_class,
 )
-from ethpm.constants import INFURA_GATEWAY_PREFIX
+from ethpm.constants import INFURA_GATEWAY_MULTIADDR
 
 OWNED_MANIFEST_PATH = V2_PACKAGES_DIR / "owned" / "1.0.0.json"
 
@@ -35,7 +35,7 @@ def fake_client():
 
 
 @pytest.mark.parametrize(
-    "base_uri,backend", ((INFURA_GATEWAY_PREFIX, InfuraIPFSBackend()),)
+    "base_uri,backend", ((INFURA_GATEWAY_MULTIADDR, InfuraIPFSBackend()),)
 )
 def test_ipfs_and_infura_gateway_backends_fetch_uri_contents(base_uri, backend):
     uri = "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV"
@@ -47,8 +47,9 @@ def test_ipfs_and_infura_gateway_backends_fetch_uri_contents(base_uri, backend):
 def test_local_ipfs_backend():
     uri = "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV"
     backend = LocalIPFSBackend()
+    backend.pin_assets(OWNED_MANIFEST_PATH.parent / "contracts" / "Owned.sol")
     contents = backend.fetch_uri_contents(uri)
-    assert contents.startswith(b"pragma")
+    assert contents.startswith(b"pragma solidity")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?
The ipfs library we were using (`ipfsapi`) has been officially deprecated for `ipfshttpclient`


### How was it fixed?
Updated dependency
Updated Infura and local ipfs backends to use MultiAddress format enforced by `ipfshttpclient`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/57713481-dac1e400-7672-11e9-8b60-f15b5cd0804f.png)
