### PR TITLE
Deprecate local ethpm.typing for eth_typing

### DIFF
--- a/ethpm/backends/base.py
+++ b/ethpm/backends/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Union
 
-from ethpm.typing import URI
+from eth_typing import URI
 
 
 class BaseURIBackend(ABC):

--- a/ethpm/backends/http.py
+++ b/ethpm/backends/http.py
@@ -1,12 +1,12 @@
 import base64
 import json
 
+from eth_typing import URI
 import requests
 
 from ethpm.backends.base import BaseURIBackend
 from ethpm.constants import GITHUB_API_AUTHORITY
 from ethpm.exceptions import CannotHandleURI
-from ethpm.typing import URI
 from ethpm.utils.uri import (
     is_valid_content_addressed_github_uri,
     validate_blob_uri_contents,

--- a/ethpm/backends/registry.py
+++ b/ethpm/backends/registry.py
@@ -1,11 +1,11 @@
 import os
 
+from eth_typing import URI
 from web3 import Web3
 from web3.providers.auto import load_provider_from_uri
 
 from ethpm.backends.base import BaseURIBackend
 from ethpm.constants import INFURA_API_KEY
-from ethpm.typing import URI
 from ethpm.utils.registry import fetch_standard_registry_abi
 from ethpm.utils.uri import parse_registry_uri
 from ethpm.validation import is_valid_registry_uri

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Generator, Optional, Tuple, Union
 
+from eth_typing import URI, Address, ContractName
 from eth_utils import to_canonical_address, to_text, to_tuple
 from web3 import Web3
 from web3.eth import Contract
@@ -15,7 +16,6 @@ from ethpm.exceptions import (
     InsufficientAssetsError,
     PyEthPMError,
 )
-from ethpm.typing import URI, Address, ContractName
 from ethpm.utils.backend import resolve_uri_contents
 from ethpm.utils.cache import cached_property
 from ethpm.utils.contract import (

--- a/ethpm/tools/builder.py
+++ b/ethpm/tools/builder.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import tempfile
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple
 
+from eth_typing import URI, HexStr, Manifest
 from eth_utils import (
     add_0x_prefix,
     is_hex,
@@ -19,7 +20,6 @@ from web3 import Web3
 from ethpm import Package
 from ethpm.backends.ipfs import BaseIPFSBackend
 from ethpm.exceptions import ManifestBuildingError, ValidationError
-from ethpm.typing import URI, HexStr, Manifest
 from ethpm.utils.chains import is_BIP122_block_uri
 from ethpm.utils.manifest_validation import (
     format_manifest,

--- a/ethpm/tools/checker.py
+++ b/ethpm/tools/checker.py
@@ -1,11 +1,11 @@
 import re
 from typing import Any, Dict
 
+from eth_typing import Manifest
 from eth_utils.toolz import assoc, assoc_in, curry
 
 from ethpm.constants import PACKAGE_NAME_REGEX
 from ethpm.tools.builder import build
-from ethpm.typing import Manifest
 
 # todo: validate no duplicate blockchain uris in deployments, if web3 is available
 

--- a/ethpm/typing/__init__.py
+++ b/ethpm/typing/__init__.py
@@ -1,1 +1,0 @@
-from .types import URI, Address, ContractName, HexStr, Manifest  # noqa: F401

--- a/ethpm/typing/types.py
+++ b/ethpm/typing/types.py
@@ -1,7 +1,0 @@
-from typing import Any, Dict, NewType
-
-Address = NewType("Address", bytes)
-ContractName = NewType("ContractName", str)
-HexStr = NewType("HexStr", str)
-Manifest = NewType("Manifest", Dict[str, Any])
-URI = NewType("URI", str)

--- a/ethpm/utils/backend.py
+++ b/ethpm/utils/backend.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Generator, Type
 
+from eth_typing import URI
 from eth_utils import to_tuple
 from ipfshttpclient.exceptions import ConnectionError
 
@@ -14,7 +15,6 @@ from ethpm.backends.ipfs import (
 )
 from ethpm.backends.registry import RegistryURIBackend
 from ethpm.exceptions import CannotHandleURI
-from ethpm.typing import URI
 
 URI_BACKENDS = [
     InfuraIPFSBackend,

--- a/ethpm/utils/chains.py
+++ b/ethpm/utils/chains.py
@@ -2,11 +2,10 @@ import re
 from typing import Tuple
 from urllib import parse
 
+from eth_typing import URI
 from eth_utils import add_0x_prefix, encode_hex, remove_0x_prefix, to_hex
 from eth_utils.toolz import curry
 from web3 import Web3
-
-from ethpm.typing import URI
 
 
 def get_genesis_block_hash(web3: Web3) -> str:

--- a/ethpm/utils/manifest_validation.py
+++ b/ethpm/utils/manifest_validation.py
@@ -1,11 +1,11 @@
 import json
 from typing import Any, Dict, List, Set
 
+from eth_typing import Manifest
 from jsonschema import ValidationError as jsonValidationError, validate
 
 from ethpm import SPEC_DIR, V2_PACKAGES_DIR
 from ethpm.exceptions import ValidationError
-from ethpm.typing import Manifest
 
 MANIFEST_SCHEMA_PATH = SPEC_DIR / "package.spec.json"
 

--- a/ethpm/utils/uri.py
+++ b/ethpm/utils/uri.py
@@ -4,12 +4,12 @@ import json
 from typing import Tuple
 from urllib import parse
 
+from eth_typing import URI
 from eth_utils import is_text, to_bytes, to_text
 import requests
 
 from ethpm.constants import GITHUB_API_AUTHORITY
 from ethpm.exceptions import CannotHandleURI, ValidationError
-from ethpm.typing import URI
 from ethpm.utils.ipfs import is_ipfs_uri
 from ethpm.validation import validate_registry_uri
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ readme = open(os.path.join(DIR, 'README.md')).read()
 extras_require={
     'test': [
         'pytest>=3.2.1,<4',
-        'pytest-ethereum>=0.1.3a.6,<1',
+        'pytest-ethereum>=0.1.3a.7,<1',
         'tox>=1.8.0,<2',
     ],
     'lint': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,6 @@ from ethpm.utils.chains import (
     get_genesis_block_hash,
 )
 
-pytest_plugins = ["pytest_ethereum.plugins"]
-
 PACKAGE_NAMES = [
     ("escrow", "1.0.3.json"),
     ("owned", "1.0.0.json"),


### PR DESCRIPTION
### What was wrong?
Unnecessary local `ethpm.typing` module can be removed now that `eth-typing` has stabilized.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/60051037-4eeaa100-968f-11e9-926a-7083c1abfb34.png)

