### PR TITLE
Write build dependency mechanism for manifest building

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -572,6 +572,40 @@ This builder function simplifies adding the same contract type deployment across
        ),
    )
 
+To add a build dependency
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   build(
+       ...,
+       build_dependency(
+           package_name,
+           uri,
+       ),
+       ...,
+   )
+   
+.. py:function:: build_dependency(package_name, uri)
+
+To add a build dependency to your manifest, just provide the package's name and a supported, content-addressed URI.
+
+.. doctest::
+
+   >>> expected_manifest = {
+   ...   'package_name': 'owned',
+   ...   'manifest_version': '2',
+   ...   'version': '1.0.0',
+   ...   'build_dependencies': {
+   ...     'owned': 'ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW',
+   ...   }
+   ... }
+   >>> built_manifest = build(
+   ...     BASE_MANIFEST,
+   ...     build_dependency('owned', 'ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW'),
+   ... )
+   >>> assert expected_manifest == built_manifest
+
 
 Checker
 -------

--- a/tests/ethpm/tools/test_builder.py
+++ b/tests/ethpm/tools/test_builder.py
@@ -664,27 +664,27 @@ def test_builder_deployment_type_complex(escrow_package):
     assert len(list(manifest["deployments"].values())[1]) == 2
 
 
-def test_builder_with_build_dependencies():
-    expected_single_build_dep = {
+def test_builder_with_single_build_dependency():
+    expected_build_dep = {
         "package": "ipfs://QmUYcVzTfSwJoigggMxeo2g5STWAgJdisQsqcXHws7b1FW"
     }
-    expected_double_build_deps = {
-        "escrow": "ipfs://QmPDwMHk8e1aMEZg3iKsUiPSkhHkywpGB3KHKM52RtGrkv",
-        "package": "ipfs://QmUYcVzTfSwJoigggMxeo2g5STWAgJdisQsqcXHws7b1FW",
-    }
-    expected_single = assoc_in(
-        BASE_MANIFEST, ["build_dependencies"], expected_single_build_dep
-    )
-    expected_double = assoc_in(
-        BASE_MANIFEST, ["build_dependencies"], expected_double_build_deps
-    )
-    actual_single = build(
+    expected = assoc_in(BASE_MANIFEST, ["build_dependencies"], expected_build_dep)
+    actual = build(
         BASE_MANIFEST,
         build_dependency(
             "package", "ipfs://QmUYcVzTfSwJoigggMxeo2g5STWAgJdisQsqcXHws7b1FW"
         ),
     )
-    actual_double = build(
+    assert actual == expected
+
+
+def test_builder_with_multiple_build_dependencies():
+    expected_build_deps = {
+        "escrow": "ipfs://QmPDwMHk8e1aMEZg3iKsUiPSkhHkywpGB3KHKM52RtGrkv",
+        "package": "ipfs://QmUYcVzTfSwJoigggMxeo2g5STWAgJdisQsqcXHws7b1FW",
+    }
+    expected = assoc_in(BASE_MANIFEST, ["build_dependencies"], expected_build_deps)
+    actual = build(
         BASE_MANIFEST,
         build_dependency(
             "package", "ipfs://QmUYcVzTfSwJoigggMxeo2g5STWAgJdisQsqcXHws7b1FW"
@@ -693,8 +693,7 @@ def test_builder_with_build_dependencies():
             "escrow", "ipfs://QmPDwMHk8e1aMEZg3iKsUiPSkhHkywpGB3KHKM52RtGrkv"
         ),
     )
-    assert actual_single == expected_single
-    assert actual_double == expected_double
+    assert actual == expected
 
 
 def test_builder_with_invalid_uri():


### PR DESCRIPTION
### What was wrong?
`builder` tool needs a mechanism for adding build dependencies to a manifest.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/60624691-353e0d80-9da3-11e9-9e9b-62b2d57e2812.png)

