### PR TITLE
Add Matomo Tracking to Docs site.

### DIFF
--- a/docs/_static/js/matomo.js
+++ b/docs/_static/js/matomo.js
@@ -1,0 +1,11 @@
+var _paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="https://matomo.ethereum.org/piwik/";
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '20']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,9 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+def setup(app):
+    app.add_js_file("js/matomo.js")
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #


### PR DESCRIPTION
### What was wrong?

Currently we do not have a good insight into our target group. In order to improve both py-ethpm itself and the documentation, it makes sense to aggregate some data.

### How was it fixed?

Add Matomo Tracking to Docs site.

Matomo is an Open Source web analytics platform that allows us
to get better insights and optimize for our audience without
the negative consequences of other compareable platforms.

Read more: https://matomo.org/why-matomo/

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://sacramento.cbslocal.com/wp-content/uploads/sites/15909776/2013/04/baby-sea-turtles.jpg)
